### PR TITLE
Align install path with systemd unit

### DIFF
--- a/hypr-smartd/Makefile
+++ b/hypr-smartd/Makefile
@@ -1,4 +1,5 @@
 BINARY=bin/hypr-smartd
+INSTALL_DIR?=$(HOME)/.local/bin
 
 .PHONY: build run install service lint test
 
@@ -10,7 +11,8 @@ run:
 	go run ./cmd/hypr-smartd --config configs/example.yaml
 
 install:
-	go install ./cmd/hypr-smartd
+	mkdir -p $(INSTALL_DIR)
+	GOBIN=$(INSTALL_DIR) go install ./cmd/hypr-smartd
 
 service:
 	systemctl --user daemon-reload

--- a/hypr-smartd/README.md
+++ b/hypr-smartd/README.md
@@ -55,14 +55,14 @@ Place the configuration at `~/.config/hypr-smartd/config.yaml` to align with the
 
 - `make build` – compile to `bin/hypr-smartd`.
 - `make run` – run the daemon against `configs/example.yaml`.
-- `make install` – install the binary to your Go `$GOBIN`.
+- `make install` – install the binary to `~/.local/bin` (override with `INSTALL_DIR=...`).
 - `make service` – reload and start the user service.
 - `make lint` – run `go vet` plus a `gofmt` check.
 - `make test` – execute unit tests.
 
 ## Systemd (user) service
 
-Install the binary with `make install`, copy `system/hypr-smartd.service` to `~/.config/systemd/user/`, then enable it:
+Install the binary with `make install` (which places it at `~/.local/bin/hypr-smartd` by default), copy `system/hypr-smartd.service` to `~/.config/systemd/user/`, then enable it:
 
 ```bash
 mkdir -p ~/.config/systemd/user/


### PR DESCRIPTION
## Summary
- ensure `make install` installs the binary into `~/.local/bin` by default
- document the default install location in the README so it matches the systemd unit

## Checklist
- [x] Install target writes `hypr-smartd` to `~/.local/bin`
- [x] Systemd docs reference the correct binary path

## How to Test
- `make install`


------
https://chatgpt.com/codex/tasks/task_e_68e07d75a7b08325b5b62e4d77ca1dfa