### PR TITLE
Add configurable client title redaction

### DIFF
--- a/cmd/hyprpal/main.go
+++ b/cmd/hyprpal/main.go
@@ -77,7 +77,7 @@ func main() {
 		exitErr(fmt.Errorf("configure dispatch strategy: %w", err))
 	}
 	logger.Infof("using %s dispatch strategy", strategy)
-	eng := engine.New(hypr, logger, modes, *dryRun)
+	eng := engine.New(hypr, logger, modes, *dryRun, cfg.RedactTitles)
 	if *startMode != "" {
 		if err := eng.SetMode(*startMode); err != nil {
 			logger.Warnf("failed to set mode %s: %v", *startMode, err)
@@ -98,6 +98,7 @@ func main() {
 			return fmt.Errorf("compile rules: %w", err)
 		}
 		eng.ReloadModes(modes)
+		eng.SetRedactTitles(cfg.RedactTitles)
 		if err := eng.Reconcile(ctx); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -3,6 +3,7 @@ managedWorkspaces:
   # hyprpal will only touch workspaces listed here unless a rule opts out.
   - 3
   - 4
+redactTitles: false # set to true to hide client titles from logs and control APIs
 modes:
   - name: Coding
     rules:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	ManagedWorkspaces []int        `yaml:"managedWorkspaces"`
 	Modes             []ModeConfig `yaml:"modes"`
+	RedactTitles      bool         `yaml:"redactTitles"`
 }
 
 // ModeConfig represents a named mode with a set of rules.


### PR DESCRIPTION
## Summary
- add a `redactTitles` toggle to the daemon config and plumb it into the engine
- redact client titles from engine state, trace logging, and dispatch logs when enabled
- document the option in the sample config and cover it with unit tests

## Acceptance Criteria
- [x] Configuration supports enabling title redaction
- [x] Engine and logs honor the redaction setting
- [x] Example configuration documents the new option

## How to test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e16e73ed00832598ff9524ca5d929c