### PR TITLE
Add interactive hsctl TUI inspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HYPRPAL_BIN=$(BIN_DIR)/hyprpal
 HSCTL_BIN=$(BIN_DIR)/hsctl
 INSTALL_DIR?=$(HOME)/.local/bin
 
-.PHONY: build run install service lint test
+.PHONY: build run tui install service lint test
 
 build:
 	mkdir -p $(BIN_DIR)
@@ -11,11 +11,14 @@ build:
 	go build -o $(HSCTL_BIN) ./cmd/hsctl
 
 run:
-	go run ./cmd/hyprpal --config configs/example.yaml
+        go run ./cmd/hyprpal --config configs/example.yaml
+
+tui:
+        go run ./cmd/hsctl tui
 
 install:
-	mkdir -p $(INSTALL_DIR)
-	GOBIN=$(INSTALL_DIR) go install ./cmd/hyprpal ./cmd/hsctl
+        mkdir -p $(INSTALL_DIR)
+        GOBIN=$(INSTALL_DIR) go install ./cmd/hyprpal ./cmd/hsctl
 
 service:
 	systemctl --user daemon-reload

--- a/internal/control/client/client.go
+++ b/internal/control/client/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hyprpal/hyprpal/internal/control"
+	"github.com/hyprpal/hyprpal/internal/state"
 )
 
 const (
@@ -29,6 +30,12 @@ type (
 	// PlanResult captures the commands returned by the daemon when planning.
 	PlanResult = control.PlanResult
 )
+
+// InspectorState captures the daemon's last reconciled world snapshot alongside mode info.
+type InspectorState struct {
+	Mode  ModeStatus   `json:"mode"`
+	World *state.World `json:"world"`
+}
 
 // New creates a client that connects to the provided socket path. When path is
 // empty, the default runtime path is used.
@@ -74,6 +81,15 @@ func (c *Client) Plan(ctx context.Context, explain bool) (PlanResult, error) {
 		return PlanResult{}, err
 	}
 	return result, nil
+}
+
+// Inspect retrieves the daemon's most recent world snapshot along with mode information.
+func (c *Client) Inspect(ctx context.Context) (InspectorState, error) {
+	var snapshot InspectorState
+	if err := c.do(ctx, control.Request{Action: control.ActionInspect}, &snapshot); err != nil {
+		return InspectorState{}, err
+	}
+	return snapshot, nil
 }
 
 func (c *Client) do(ctx context.Context, req control.Request, out any) error {

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -14,7 +14,8 @@ const (
 	ActionModeGet = "mode.get"
 	ActionModeSet = "mode.set"
 	ActionReload  = "reload"
-	ActionPlan    = "plan"
+        ActionPlan    = "plan"
+        ActionInspect = "inspect"
 
 	// Response statuses.
 	StatusOK    = "ok"

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -197,7 +197,7 @@ func (e *Engine) reconcileAndApply(ctx context.Context) error {
 	redact := e.redactTitlesEnabled()
 	storedWorld := world
 	if redact {
-		storedWorld = cloneWorld(world)
+		storedWorld = state.CloneWorld(world)
 		redactWorldTitles(storedWorld)
 	}
 	e.mu.Lock()
@@ -276,7 +276,7 @@ func (e *Engine) PreviewPlan(ctx context.Context, explain bool) ([]PlannedComman
 	}
 	storedWorld := world
 	if e.redactTitlesEnabled() {
-		storedWorld = cloneWorld(world)
+		storedWorld = state.CloneWorld(world)
 		redactWorldTitles(storedWorld)
 	}
 	e.mu.Lock()
@@ -461,23 +461,6 @@ func (e *Engine) trace(event string, fields map[string]any) {
 }
 
 const redactedTitle = "[redacted]"
-
-func cloneWorld(src *state.World) *state.World {
-	if src == nil {
-		return nil
-	}
-	copyWorld := *src
-	if len(src.Clients) > 0 {
-		copyWorld.Clients = append([]state.Client(nil), src.Clients...)
-	}
-	if len(src.Workspaces) > 0 {
-		copyWorld.Workspaces = append([]state.Workspace(nil), src.Workspaces...)
-	}
-	if len(src.Monitors) > 0 {
-		copyWorld.Monitors = append([]state.Monitor(nil), src.Monitors...)
-	}
-	return &copyWorld
-}
 
 func redactWorldTitles(world *state.World) {
 	if world == nil {

--- a/internal/state/world.go
+++ b/internal/state/world.go
@@ -149,3 +149,21 @@ func (w *World) MonitorForWorkspace(id int) (*Monitor, error) {
 	}
 	return mon, nil
 }
+
+// CloneWorld returns a deep copy of the provided world snapshot.
+func CloneWorld(src *World) *World {
+	if src == nil {
+		return nil
+	}
+	copyWorld := *src
+	if len(src.Clients) > 0 {
+		copyWorld.Clients = append([]Client(nil), src.Clients...)
+	}
+	if len(src.Workspaces) > 0 {
+		copyWorld.Workspaces = append([]Workspace(nil), src.Workspaces...)
+	}
+	if len(src.Monitors) > 0 {
+		copyWorld.Monitors = append([]Monitor(nil), src.Monitors...)
+	}
+	return &copyWorld
+}

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -1,0 +1,261 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/hyprpal/hyprpal/internal/control/client"
+	"github.com/hyprpal/hyprpal/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/state"
+)
+
+const (
+	defaultRefresh = 500 * time.Millisecond
+	titleWidth     = 48
+)
+
+// Renderer periodically polls the daemon and renders a textual dashboard.
+type Renderer struct {
+	Client  *client.Client
+	Writer  io.Writer
+	Refresh time.Duration
+}
+
+// New returns a renderer configured with sensible defaults.
+func New(cli *client.Client, w io.Writer) *Renderer {
+	return &Renderer{Client: cli, Writer: w, Refresh: defaultRefresh}
+}
+
+// Run starts the render loop until the context is cancelled.
+func (r *Renderer) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if r.Writer == nil {
+		r.Writer = os.Stdout
+	}
+	if r.Client == nil {
+		return fmt.Errorf("tui renderer requires a control client")
+	}
+
+	refresh := r.Refresh
+	if refresh <= 0 {
+		refresh = defaultRefresh
+	}
+
+	ticker := time.NewTicker(refresh)
+	defer ticker.Stop()
+
+	fmt.Fprint(r.Writer, "\033[?25l")
+	defer fmt.Fprint(r.Writer, "\033[?25h")
+
+	r.render(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			r.render(ctx)
+		}
+	}
+}
+
+func (r *Renderer) render(ctx context.Context) {
+	snapshot, err := r.Client.Inspect(ctx)
+
+	var buf bytes.Buffer
+	buf.WriteString("\033[H\033[2J")
+	buf.WriteString("hyprpal inspector — Ctrl+C to exit\n")
+	buf.WriteString(time.Now().Format(time.RFC1123))
+	buf.WriteString("\n\n")
+
+	if err != nil {
+		buf.WriteString(fmt.Sprintf("error: %v\n", err))
+		fmt.Fprint(r.Writer, buf.String())
+		return
+	}
+
+	buf.WriteString(formatMode(snapshot.Mode))
+	buf.WriteByte('\n')
+	if snapshot.World == nil {
+		buf.WriteString("Waiting for daemon to publish world snapshot...\n")
+		fmt.Fprint(r.Writer, buf.String())
+		return
+	}
+
+	buf.WriteString(renderMonitors(snapshot.World))
+	buf.WriteString(renderWorkspaces(snapshot.World))
+	buf.WriteString(renderClients(snapshot.World))
+	fmt.Fprint(r.Writer, buf.String())
+}
+
+func formatMode(status client.ModeStatus) string {
+	active := status.Active
+	if active == "" {
+		active = "(none)"
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Active mode: %s\n", active))
+	if len(status.Available) > 0 {
+		b.WriteString("Available: ")
+		b.WriteString(strings.Join(status.Available, ", "))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func renderMonitors(world *state.World) string {
+	var b strings.Builder
+	b.WriteString("Monitors:\n")
+	monitors := append([]state.Monitor(nil), world.Monitors...)
+	if len(monitors) == 0 {
+		b.WriteString("  (none)\n\n")
+		return b.String()
+	}
+	sort.Slice(monitors, func(i, j int) bool {
+		return monitors[i].ID < monitors[j].ID
+	})
+	tw := tabwriter.NewWriter(&b, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tName\tGeometry\tActive WS\tFocused WS")
+	for _, mon := range monitors {
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%d\t%d\n", mon.ID, mon.Name, formatRect(mon.Rectangle), mon.ActiveWorkspaceID, mon.FocusedWorkspaceID)
+	}
+	tw.Flush()
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func renderWorkspaces(world *state.World) string {
+	var b strings.Builder
+	b.WriteString("Workspaces:\n")
+	workspaces := append([]state.Workspace(nil), world.Workspaces...)
+	if len(workspaces) == 0 {
+		b.WriteString("  (none)\n\n")
+		return b.String()
+	}
+	sort.Slice(workspaces, func(i, j int) bool {
+		return workspaces[i].ID < workspaces[j].ID
+	})
+	tw := tabwriter.NewWriter(&b, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tName\tMonitor\tWindows")
+	for _, ws := range workspaces {
+		id := fmt.Sprintf("%d", ws.ID)
+		if ws.ID == world.ActiveWorkspaceID {
+			id += "*"
+		}
+		name := ws.Name
+		if name == "" {
+			name = "(unnamed)"
+		}
+		monitor := ws.MonitorName
+		if monitor == "" {
+			monitor = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\n", id, name, monitor, ws.Windows)
+	}
+	tw.Flush()
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func renderClients(world *state.World) string {
+	var b strings.Builder
+	b.WriteString("Clients:\n")
+	clients := append([]state.Client(nil), world.Clients...)
+	if len(clients) == 0 {
+		b.WriteString("  (none)\n\n")
+		return b.String()
+	}
+	sort.Slice(clients, func(i, j int) bool {
+		if clients[i].WorkspaceID == clients[j].WorkspaceID {
+			if clients[i].MonitorName == clients[j].MonitorName {
+				return clients[i].Class < clients[j].Class
+			}
+			return clients[i].MonitorName < clients[j].MonitorName
+		}
+		return clients[i].WorkspaceID < clients[j].WorkspaceID
+	})
+	workspaceNames := make(map[int]string, len(world.Workspaces))
+	for _, ws := range world.Workspaces {
+		workspaceNames[ws.ID] = ws.Name
+	}
+	tw := tabwriter.NewWriter(&b, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "Addr\tClass\tTitle\tWorkspace\tMonitor\tState")
+	for _, cl := range clients {
+		address := cl.Address
+		if address == "" {
+			address = "-"
+		}
+		if cl.Address == world.ActiveClientAddress {
+			address = "*" + address
+		}
+		className := cl.Class
+		if className == "" {
+			className = "(unknown)"
+		}
+		title := cl.Title
+		if title == "" {
+			title = "(untitled)"
+		}
+		title = truncate(title, titleWidth)
+		workspaceLabel := fmt.Sprintf("%d", cl.WorkspaceID)
+		if name := workspaceNames[cl.WorkspaceID]; name != "" {
+			workspaceLabel = fmt.Sprintf("%s (%s)", workspaceLabel, name)
+		}
+		if cl.WorkspaceID == world.ActiveWorkspaceID {
+			workspaceLabel += "*"
+		}
+		monitor := cl.MonitorName
+		if monitor == "" {
+			monitor = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", address, className, title, workspaceLabel, monitor, clientState(cl, world.ActiveClientAddress))
+	}
+	tw.Flush()
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func formatRect(rect layout.Rect) string {
+	return fmt.Sprintf("%.0fx%.0f @ %.0f,%.0f", rect.Width, rect.Height, rect.X, rect.Y)
+}
+
+func truncate(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 1 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-1]) + "…"
+}
+
+func clientState(cl state.Client, active string) string {
+	var parts []string
+	if cl.Address == active {
+		parts = append(parts, "active")
+	} else if cl.Focused {
+		parts = append(parts, "focused")
+	}
+	if cl.Floating {
+		parts = append(parts, "floating")
+	}
+	if cl.FullscreenMode > 0 {
+		parts = append(parts, "fullscreen")
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, ", ")
+}


### PR DESCRIPTION
## Summary
- add a `hsctl tui` subcommand with a renderer that shows the daemon world snapshot and refreshes periodically
- expose the inspector payload via the control server/client and reuse a shared world clone helper
- add a Makefile `tui` helper so the interactive dashboard is built/installed alongside existing binaries

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e175850aa0832581e8550764221ad5