### PR TITLE
feat: expose inspector history over control API

### DIFF
--- a/internal/control/client/client.go
+++ b/internal/control/client/client.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hyprpal/hyprpal/internal/control"
-	"github.com/hyprpal/hyprpal/internal/state"
 )
 
 const (
@@ -29,13 +28,11 @@ type (
 	PlanCommand = control.PlanCommand
 	// PlanResult captures the commands returned by the daemon when planning.
 	PlanResult = control.PlanResult
+	// RuleEvaluation mirrors the inspector rule log entry returned by the daemon.
+	RuleEvaluation = control.RuleEvaluation
+	// InspectorState captures the daemon's inspector payload.
+	InspectorState = control.InspectorSnapshot
 )
-
-// InspectorState captures the daemon's last reconciled world snapshot alongside mode info.
-type InspectorState struct {
-	Mode  ModeStatus   `json:"mode"`
-	World *state.World `json:"world"`
-}
 
 // New creates a client that connects to the provided socket path. When path is
 // empty, the default runtime path is used.
@@ -83,10 +80,15 @@ func (c *Client) Plan(ctx context.Context, explain bool) (PlanResult, error) {
 	return result, nil
 }
 
-// Inspect retrieves the daemon's most recent world snapshot along with mode information.
+// Inspect retrieves the daemon's most recent world snapshot, mode information, and rule log.
 func (c *Client) Inspect(ctx context.Context) (InspectorState, error) {
+	return c.InspectorGet(ctx)
+}
+
+// InspectorGet retrieves the inspector payload via the control socket.
+func (c *Client) InspectorGet(ctx context.Context) (InspectorState, error) {
 	var snapshot InspectorState
-	if err := c.do(ctx, control.Request{Action: control.ActionInspect}, &snapshot); err != nil {
+	if err := c.do(ctx, control.Request{Action: control.ActionInspectorGet}, &snapshot); err != nil {
 		return InspectorState{}, err
 	}
 	return snapshot, nil

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -145,8 +145,8 @@ func (s *Server) handle(ctx context.Context, conn net.Conn) {
 		s.handleReload(conn)
 	case ActionPlan:
 		s.handlePlan(ctx, conn, req.Params)
-	case ActionInspect:
-		s.handleInspect(conn)
+	case ActionInspectorGet, ActionInspect:
+		s.handleInspectorGet(conn)
 	default:
 		s.writeError(conn, fmt.Errorf("unknown action %q", req.Action))
 	}
@@ -202,18 +202,40 @@ func (s *Server) handlePlan(ctx context.Context, conn net.Conn, params map[strin
 	s.writeOK(conn, result)
 }
 
-func (s *Server) handleInspect(conn net.Conn) {
-	payload := struct {
-		Mode  ModeStatus   `json:"mode"`
-		World *state.World `json:"world"`
-	}{
+func (s *Server) handleInspectorGet(conn net.Conn) {
+	snapshot := InspectorSnapshot{
 		Mode: ModeStatus{
 			Active:    s.engine.ActiveMode(),
 			Available: s.engine.AvailableModes(),
 		},
 		World: state.CloneWorld(s.engine.LastWorld()),
 	}
-	s.writeOK(conn, payload)
+	history := s.engine.RuleEvaluationHistory()
+	if len(history) > 0 {
+		snapshot.History = make([]RuleEvaluation, 0, len(history))
+		for _, entry := range history {
+			snapshot.History = append(snapshot.History, RuleEvaluation{
+				Timestamp: entry.Timestamp,
+				Mode:      entry.Mode,
+				Rule:      entry.Rule,
+				Status:    string(entry.Status),
+				Commands:  cloneInspectorCommands(entry.Commands),
+				Error:     entry.Error,
+			})
+		}
+	}
+	s.writeOK(conn, snapshot)
+}
+
+func cloneInspectorCommands(cmds [][]string) [][]string {
+	if len(cmds) == 0 {
+		return nil
+	}
+	out := make([][]string, len(cmds))
+	for i, cmd := range cmds {
+		out[i] = append([]string(nil), cmd...)
+	}
+	return out
 }
 
 func (s *Server) writeOK(conn net.Conn, data any) {

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"time"
+
+	"github.com/hyprpal/hyprpal/internal/state"
 )
 
 const (
@@ -11,11 +14,12 @@ const (
 	SocketFileName = "control.sock"
 
 	// Action names supported by the control protocol.
-	ActionModeGet = "mode.get"
-	ActionModeSet = "mode.set"
-	ActionReload  = "reload"
-        ActionPlan    = "plan"
-        ActionInspect = "inspect"
+	ActionModeGet      = "mode.get"
+	ActionModeSet      = "mode.set"
+	ActionReload       = "reload"
+	ActionPlan         = "plan"
+	ActionInspect      = "inspect" // legacy alias for inspector.get
+	ActionInspectorGet = "inspector.get"
 
 	// Response statuses.
 	StatusOK    = "ok"
@@ -50,6 +54,23 @@ type PlanCommand struct {
 // PlanResult captures the commands returned by the daemon when planning.
 type PlanResult struct {
 	Commands []PlanCommand `json:"commands"`
+}
+
+// RuleEvaluation captures a single rule evaluation outcome for the inspector view.
+type RuleEvaluation struct {
+	Timestamp time.Time  `json:"timestamp"`
+	Mode      string     `json:"mode"`
+	Rule      string     `json:"rule"`
+	Status    string     `json:"status"`
+	Commands  [][]string `json:"commands,omitempty"`
+	Error     string     `json:"error,omitempty"`
+}
+
+// InspectorSnapshot captures the daemon's last reconciled world snapshot, mode state, and rule log.
+type InspectorSnapshot struct {
+	Mode    ModeStatus       `json:"mode"`
+	World   *state.World     `json:"world"`
+	History []RuleEvaluation `json:"history,omitempty"`
 }
 
 // DefaultSocketPath returns the expected location of the hyprpal control socket.

--- a/internal/engine/inspector.go
+++ b/internal/engine/inspector.go
@@ -1,0 +1,87 @@
+package engine
+
+import (
+	"sync"
+	"time"
+)
+
+type RuleEvaluationStatus string
+
+const (
+	RuleEvaluationStatusApplied RuleEvaluationStatus = "applied"
+	RuleEvaluationStatusDryRun  RuleEvaluationStatus = "dry-run"
+	RuleEvaluationStatusError   RuleEvaluationStatus = "error"
+
+	inspectorHistoryLimit = 128
+)
+
+type RuleEvaluation struct {
+	Timestamp time.Time            `json:"timestamp"`
+	Mode      string               `json:"mode"`
+	Rule      string               `json:"rule"`
+	Status    RuleEvaluationStatus `json:"status"`
+	Commands  [][]string           `json:"commands,omitempty"`
+	Error     string               `json:"error,omitempty"`
+}
+
+type evaluationLog struct {
+	mu      sync.Mutex
+	entries []RuleEvaluation
+	limit   int
+}
+
+func newEvaluationLog(limit int) *evaluationLog {
+	if limit <= 0 {
+		limit = inspectorHistoryLimit
+	}
+	return &evaluationLog{limit: limit}
+}
+
+func (l *evaluationLog) record(entry RuleEvaluation) {
+	if l == nil {
+		return
+	}
+	cloned := cloneCommands(entry.Commands)
+	entry.Commands = cloned
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.limit > 0 && len(l.entries) == l.limit {
+		copy(l.entries, l.entries[1:])
+		l.entries = l.entries[:l.limit-1]
+	}
+	l.entries = append(l.entries, entry)
+}
+
+func (l *evaluationLog) snapshot() []RuleEvaluation {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.entries) == 0 {
+		return nil
+	}
+	out := make([]RuleEvaluation, len(l.entries))
+	for i, entry := range l.entries {
+		out[i] = RuleEvaluation{
+			Timestamp: entry.Timestamp,
+			Mode:      entry.Mode,
+			Rule:      entry.Rule,
+			Status:    entry.Status,
+			Commands:  cloneCommands(entry.Commands),
+			Error:     entry.Error,
+		}
+	}
+	return out
+}
+
+func cloneCommands(src [][]string) [][]string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([][]string, len(src))
+	for i, cmd := range src {
+		out[i] = append([]string(nil), cmd...)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- add inspector control types and new `inspector.get` action constant
- expose the inspector snapshot with rule-evaluation history from the control server and client
- track rule evaluation outcomes inside the engine for the inspector log

## Checklist
- [x] Control API responds with world snapshot and rule-evaluation history
- [x] Client helper can fetch the inspector payload via the new action

## How to test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e17824fb608325b537316f1f621c9b