### PR TITLE
Add example presets for coding, gaming, streaming, and ultrawide setups

### DIFF
--- a/examples/coding.md
+++ b/examples/coding.md
@@ -1,0 +1,15 @@
+# Coding preset
+
+This preset assumes a dual-monitor workstation with the primary development monitor exposed as `DP-1` and a secondary communications monitor exposed as `HDMI-A-1`.
+
+## Application targets
+- IDE window with class `code` (Visual Studio Code) on workspace `1`
+- Terminal windows with class `Alacritty` to dock alongside the IDE
+- Communication clients with classes `Slack` or `discord` on workspace `3`
+
+## Workspace layout assumptions
+- Workspace `1` is your main development surface on `DP-1`
+- Workspace `2` is left unmanaged for ad-hoc windows
+- Workspace `3` lives on `HDMI-A-1` for persistent comms
+
+Adjust monitor names, classes, or workspace IDs to match your Hyprland environment.

--- a/examples/coding.yaml
+++ b/examples/coding.yaml
@@ -1,0 +1,49 @@
+# Example Hyprpal preset for a development-focused workstation.
+managedWorkspaces:
+  - 1
+  - 2
+  - 3
+modes:
+  - name: Coding
+    rules:
+      - name: Keep IDE primary on workspace 1
+        when:
+          all:
+            - mode: Coding
+            - workspace.id: 1
+            - monitor.name: DP-1
+            - app.class: code
+        actions:
+          - type: layout.fullscreen
+            params:
+              target: active
+      - name: Dock terminal companion
+        when:
+          all:
+            - mode: Coding
+            - workspace.id: 1
+            - monitor.name: DP-1
+            - apps.present: [Alacritty]
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 1
+              side: left
+              widthPercent: 30
+              match:
+                class: Alacritty
+      - name: Pin communications on workspace 3
+        when:
+          all:
+            - mode: Coding
+            - workspace.id: 3
+            - monitor.name: HDMI-A-1
+            - apps.present: [Slack, discord]
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 3
+              side: right
+              widthPercent: 25
+              match:
+                anyClass: [Slack, discord]

--- a/examples/gaming.md
+++ b/examples/gaming.md
@@ -1,0 +1,13 @@
+# Gaming preset
+
+This layout expects a primary high-refresh monitor advertised as `DP-1` and an optional secondary monitor for chat/overlays.
+
+## Application targets
+- Game or launcher windows with classes `steam`, `heroic`, or `lutris`
+- Voice chat overlay using class `vesktop`
+
+## Workspace layout assumptions
+- Workspace `5` is the main play surface on `DP-1`
+- Workspace `6` hosts overlays or voice chat
+
+Consider enabling `redactTitles` if your overlays expose sensitive information. Update the class names if your launcher uses a different identifier.

--- a/examples/gaming.yaml
+++ b/examples/gaming.yaml
@@ -1,0 +1,43 @@
+# Example Hyprpal preset for a dedicated gaming workspace.
+managedWorkspaces:
+  - 5
+  - 6
+redactTitles: true
+modes:
+  - name: Gaming
+    rules:
+      - name: Force fullscreen on primary monitor
+        when:
+          all:
+            - mode: Gaming
+            - monitor.name: DP-1
+            - workspace.id: 5
+        allowUnmanaged: true
+        actions:
+          - type: layout.fullscreen
+            params:
+              target: active
+      - name: Fullscreen popular launchers
+        when:
+          mode: Gaming
+        allowUnmanaged: true
+        actions:
+          - type: layout.fullscreen
+            params:
+              target: match
+              match:
+                anyClass: [steam, heroic, lutris]
+      - name: Dock voice chat overlay
+        when:
+          all:
+            - mode: Gaming
+            - workspace.id: 6
+            - apps.present: [vesktop]
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 6
+              side: left
+              widthPercent: 20
+              match:
+                class: vesktop

--- a/examples/streaming.md
+++ b/examples/streaming.md
@@ -1,0 +1,15 @@
+# Streaming preset
+
+Designed for a creator setup with a capture monitor (`DP-1`) and a secondary display (`HDMI-A-1`) used for chat and alert monitoring.
+
+## Application targets
+- OBS Studio with class `obs`
+- Browser windows with classes `firefox` or `chromium` for chat dashboards
+- Music player with class `spotify`
+
+## Workspace layout assumptions
+- Workspace `7` on `DP-1` is dedicated to OBS controls
+- Workspace `8` on `HDMI-A-1` keeps chat and alerts docked to the right
+- Workspace `9` holds background music or ambience controls
+
+Tailor the workspace IDs, monitor names, and application classes to match your streaming rig.

--- a/examples/streaming.yaml
+++ b/examples/streaming.yaml
@@ -1,0 +1,47 @@
+# Example Hyprpal preset for creators capturing and monitoring a stream.
+managedWorkspaces:
+  - 7
+  - 8
+  - 9
+modes:
+  - name: Streaming
+    rules:
+      - name: Keep OBS centered on control workspace
+        when:
+          all:
+            - mode: Streaming
+            - workspace.id: 7
+            - app.class: obs
+        actions:
+          - type: layout.fullscreen
+            params:
+              target: active
+      - name: Dock chat and alerts on auxiliary monitor
+        when:
+          all:
+            - mode: Streaming
+            - workspace.id: 8
+            - monitor.name: HDMI-A-1
+            - apps.present: [firefox, chromium]
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 8
+              side: right
+              widthPercent: 35
+              match:
+                anyClass: [firefox, chromium]
+      - name: Keep music player slim on preview workspace
+        when:
+          all:
+            - mode: Streaming
+            - workspace.id: 9
+            - apps.present: [spotify]
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 9
+              side: left
+              widthPercent: 25
+              match:
+                class: spotify

--- a/examples/ultrawide.md
+++ b/examples/ultrawide.md
@@ -1,0 +1,15 @@
+# Ultrawide preset
+
+Optimized for a 21:9 monitor exposed as `DP-2` with an auxiliary display on `HDMI-A-1` for cinematic or focus workspaces.
+
+## Application targets
+- Primary focus app (any class) centered on workspace `10`
+- Reference browsers with classes `Firefox` or `qutebrowser`
+- Messaging apps with classes `Slack` or `TelegramDesktop`
+
+## Workspace layout assumptions
+- Workspace `10` lives on the ultrawide `DP-2` monitor and is split into left/right wings plus a central focus zone
+- Workspace `11` on `HDMI-A-1` is a fullscreen cinematic or media surface
+- Workspace `1` remains managed for quick tasks or overflow
+
+Adjust widths, monitor identifiers, and class names to align with your actual setup.

--- a/examples/ultrawide.yaml
+++ b/examples/ultrawide.yaml
@@ -1,0 +1,56 @@
+# Example Hyprpal preset for an ultrawide workstation with focused zones.
+managedWorkspaces:
+  - 1
+  - 10
+  - 11
+modes:
+  - name: Ultrawide
+    rules:
+      - name: Anchor primary app center stage
+        when:
+          all:
+            - mode: Ultrawide
+            - workspace.id: 10
+            - monitor.name: DP-2
+        actions:
+          - type: layout.fullscreen
+            params:
+              target: active
+      - name: Stage reference docs on right wing
+        when:
+          all:
+            - mode: Ultrawide
+            - workspace.id: 10
+            - apps.present: [Firefox, qutebrowser]
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 10
+              side: right
+              widthPercent: 30
+              match:
+                anyClass: [Firefox, qutebrowser]
+      - name: Stage messaging stack on left wing
+        when:
+          all:
+            - mode: Ultrawide
+            - workspace.id: 10
+            - apps.present: [Slack, TelegramDesktop]
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 10
+              side: left
+              widthPercent: 25
+              match:
+                anyClass: [Slack, TelegramDesktop]
+      - name: Make cinematic workspace fullscreen
+        when:
+          all:
+            - mode: Ultrawide
+            - workspace.id: 11
+            - monitor.name: HDMI-A-1
+        actions:
+          - type: layout.fullscreen
+            params:
+              target: active


### PR DESCRIPTION
## Summary
- add an examples/ directory with scenario-specific Hyprpal presets
- document monitor, application class, and workspace assumptions for each preset

## Acceptance Criteria
- [x] New example presets exist for coding, gaming, streaming, and ultrawide use cases
- [x] Each preset includes guidance for adapting monitor names, classes, and workspace IDs

## How to Test
1. Review the YAML files in `examples/` to ensure the rules align with your environment.
2. Launch `hyprpal` with `--config` pointing at one of the new presets and verify window layout behavior on matching monitors/workspaces.


------
https://chatgpt.com/codex/tasks/task_e_68e18d3328a48325b5eee01d1960830b