### PR TITLE
Add configurable layout gaps and tolerance controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Configuration is YAML with modes, rules, and actions. Start by copying a preset 
 managedWorkspaces:
   - 3
   - 4
+gaps:
+  inner: 8
+  outer: 20
+placementTolerancePx: 2
 modes:
   - name: Coding
     rules:
@@ -100,7 +104,7 @@ modes:
               target: active
 ```
 
-Place the configuration at `~/.config/hyprpal/config.yaml` to align with the provided systemd unit. `managedWorkspaces` scopes hyprpal’s actions to the listed workspace IDs by default—rules will be skipped elsewhere unless they set `allowUnmanaged: true`. Leaving the list empty allows every workspace to be managed. `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. The daemon automatically reloads when this file changes and still honors `SIGHUP` (e.g. `systemctl --user reload hyprpal`) for manual reloads. Runtime flags such as `--dispatch=socket|hyprctl`, `--dry-run`, `--log-level`, and `--mode` let you adjust behavior without editing the config file.
+Place the configuration at `~/.config/hyprpal/config.yaml` to align with the provided systemd unit. `managedWorkspaces` scopes hyprpal’s actions to the listed workspace IDs by default—rules will be skipped elsewhere unless they set `allowUnmanaged: true`. Leaving the list empty allows every workspace to be managed. Use the root-level `gaps` block to mirror your Hyprland gap settings (outer gap trims the monitor rectangle, inner gap is placed between floated windows). `placementTolerancePx` controls how much wiggle room hyprpal allows when comparing rectangles for idempotence; keep it aligned with Hyprland’s rounding behavior (default `2px`, or `0` for exact matches). `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. The daemon automatically reloads when this file changes and still honors `SIGHUP` (e.g. `systemctl --user reload hyprpal`) for manual reloads. Runtime flags such as `--dispatch=socket|hyprctl`, `--dry-run`, `--log-level`, and `--mode` let you adjust behavior without editing the config file.
 
 ### Adjust presets for your setup
 

--- a/cmd/hyprpal/main.go
+++ b/cmd/hyprpal/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyprpal/hyprpal/internal/control"
 	"github.com/hyprpal/hyprpal/internal/engine"
 	"github.com/hyprpal/hyprpal/internal/ipc"
+	"github.com/hyprpal/hyprpal/internal/layout"
 	"github.com/hyprpal/hyprpal/internal/rules"
 	"github.com/hyprpal/hyprpal/internal/util"
 )
@@ -77,7 +78,10 @@ func main() {
 		exitErr(fmt.Errorf("configure dispatch strategy: %w", err))
 	}
 	logger.Infof("using %s dispatch strategy", strategy)
-	eng := engine.New(hypr, logger, modes, *dryRun, cfg.RedactTitles)
+	eng := engine.New(hypr, logger, modes, *dryRun, cfg.RedactTitles, layout.Gaps{
+		Inner: cfg.Gaps.Inner,
+		Outer: cfg.Gaps.Outer,
+	}, cfg.PlacementTolerancePx)
 	if *startMode != "" {
 		if err := eng.SetMode(*startMode); err != nil {
 			logger.Warnf("failed to set mode %s: %v", *startMode, err)
@@ -99,6 +103,10 @@ func main() {
 		}
 		eng.ReloadModes(modes)
 		eng.SetRedactTitles(cfg.RedactTitles)
+		eng.SetLayoutParameters(layout.Gaps{
+			Inner: cfg.Gaps.Inner,
+			Outer: cfg.Gaps.Outer,
+		}, cfg.PlacementTolerancePx)
 		if err := eng.Reconcile(ctx); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -4,6 +4,10 @@ managedWorkspaces:
   - 3
   - 4
 redactTitles: false # set to true to hide client titles from logs and control APIs
+gaps:
+  inner: 8  # pixels between floating windows
+  outer: 20 # pixels around monitor edges
+placementTolerancePx: 2.0 # slack for idempotence checks; set 0 for exact matches
 modes:
   - name: Coding
     rules:

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -27,11 +27,13 @@ type Engine struct {
 	hyprctl hyprctlClient
 	logger  *util.Logger
 
-	modes        map[string]rules.Mode
-	modeOrder    []string
-	activeMode   string
-	dryRun       bool
-	redactTitles bool
+	modes              map[string]rules.Mode
+	modeOrder          []string
+	activeMode         string
+	dryRun             bool
+	redactTitles       bool
+	gaps               layout.Gaps
+	placementTolerance float64
 
 	mu          sync.Mutex
 	debounce    map[string]time.Time
@@ -81,7 +83,7 @@ type ruleCheckHistory struct {
 }
 
 // New creates a new engine instance.
-func New(hyprctl hyprctlClient, logger *util.Logger, modes []rules.Mode, dryRun bool, redactTitles bool) *Engine {
+func New(hyprctl hyprctlClient, logger *util.Logger, modes []rules.Mode, dryRun bool, redactTitles bool, gaps layout.Gaps, placementTolerance float64) *Engine {
 	modeMap := make(map[string]rules.Mode)
 	order := make([]string, 0, len(modes))
 	for _, m := range modes {
@@ -93,18 +95,20 @@ func New(hyprctl hyprctlClient, logger *util.Logger, modes []rules.Mode, dryRun 
 		active = order[0]
 	}
 	return &Engine{
-		hyprctl:      hyprctl,
-		logger:       logger,
-		modes:        modeMap,
-		modeOrder:    order,
-		activeMode:   active,
-		dryRun:       dryRun,
-		redactTitles: redactTitles,
-		debounce:     make(map[string]time.Time),
-		cooldown:     make(map[string]time.Time),
-		execHistory:  make(map[string][]time.Time),
-		evalLog:      newEvaluationLog(0),
-		ruleChecks:   newRuleCheckHistory(0),
+		hyprctl:            hyprctl,
+		logger:             logger,
+		modes:              modeMap,
+		modeOrder:          order,
+		activeMode:         active,
+		dryRun:             dryRun,
+		redactTitles:       redactTitles,
+		gaps:               gaps,
+		placementTolerance: placementTolerance,
+		debounce:           make(map[string]time.Time),
+		cooldown:           make(map[string]time.Time),
+		execHistory:        make(map[string][]time.Time),
+		evalLog:            newEvaluationLog(0),
+		ruleChecks:         newRuleCheckHistory(0),
 	}
 }
 
@@ -167,6 +171,14 @@ func (e *Engine) SetMode(name string) error {
 func (e *Engine) SetRedactTitles(enabled bool) {
 	e.mu.Lock()
 	e.redactTitles = enabled
+	e.mu.Unlock()
+}
+
+// SetLayoutParameters updates the gap and tolerance configuration.
+func (e *Engine) SetLayoutParameters(gaps layout.Gaps, tolerance float64) {
+	e.mu.Lock()
+	e.gaps = gaps
+	e.placementTolerance = tolerance
 	e.mu.Unlock()
 }
 
@@ -361,6 +373,8 @@ func (e *Engine) evaluate(world *state.World, now time.Time, log bool) (layout.P
 	e.mu.Lock()
 	activeMode := e.activeMode
 	mode, ok := e.modes[activeMode]
+	gaps := e.gaps
+	tolerance := e.placementTolerance
 	e.mu.Unlock()
 	if !ok {
 		if log {
@@ -417,11 +431,13 @@ func (e *Engine) evaluate(world *state.World, now time.Time, log bool) (layout.P
 		rulePlan := layout.Plan{}
 		for _, action := range rule.Actions {
 			p, err := action.Plan(rules.ActionContext{
-				World:             world,
-				Logger:            e.logger,
-				RuleName:          rule.Name,
-				ManagedWorkspaces: rule.ManagedWorkspaces,
-				AllowUnmanaged:    rule.AllowUnmanaged,
+				World:              world,
+				Logger:             e.logger,
+				RuleName:           rule.Name,
+				ManagedWorkspaces:  rule.ManagedWorkspaces,
+				AllowUnmanaged:     rule.AllowUnmanaged,
+				Gaps:               gaps,
+				PlacementTolerance: tolerance,
 			})
 			if err != nil {
 				e.logger.Errorf("rule %s action error: %v", rule.Name, err)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -101,7 +101,7 @@ func TestReconcileAndApplyLogsDebounceSkip(t *testing.T) {
 			Debounce: time.Second,
 		}},
 	}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
 	key := mode.Name + ":" + mode.Rules[0].Name
 	eng.debounce[key] = time.Now()
 
@@ -133,7 +133,7 @@ func TestReconcileSkipsRulesDuringCooldown(t *testing.T) {
 		Actions: []rules.Action{stubAction{plan: actPlan}},
 	}
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
 
 	if err := eng.reconcileAndApply(context.Background()); err != nil {
 		t.Fatalf("first reconcileAndApply returned error: %v", err)
@@ -172,7 +172,7 @@ func TestReconcileUsesBatchDispatcherWhenAvailable(t *testing.T) {
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
 	var logs bytes.Buffer
 	logger := util.NewLoggerWithWriter(util.LevelInfo, &logs)
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
 
 	if err := eng.reconcileAndApply(context.Background()); err != nil {
 		t.Fatalf("reconcileAndApply returned error: %v", err)
@@ -203,7 +203,7 @@ func TestRuleExecutionTrackingAllowsNormalFlow(t *testing.T) {
 		Actions: []rules.Action{stubAction{plan: plan}},
 	}
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
 
 	if err := eng.reconcileAndApply(context.Background()); err != nil {
 		t.Fatalf("reconcileAndApply returned error: %v", err)
@@ -231,7 +231,7 @@ func TestRuleExecutionTrackingBelowThreshold(t *testing.T) {
 		Actions: []rules.Action{stubAction{plan: plan}},
 	}
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
 	key := mode.Name + ":" + rule.Name
 
 	for i := 0; i < ruleBurstThreshold; i++ {
@@ -264,7 +264,7 @@ func TestRuleExecutionTrackingExceedsThreshold(t *testing.T) {
 		Actions: []rules.Action{stubAction{plan: plan}},
 	}
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
 	key := mode.Name + ":" + rule.Name
 
 	for i := 0; i < ruleBurstThreshold; i++ {
@@ -321,7 +321,7 @@ func TestTraceLoggingDryRunSequence(t *testing.T) {
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
 	var logs bytes.Buffer
 	logger := util.NewLoggerWithWriter(util.LevelTrace, &logs)
-	eng := New(hypr, logger, []rules.Mode{mode}, true, false)
+	eng := New(hypr, logger, []rules.Mode{mode}, true, false, layout.Gaps{}, 2)
 	eng.mu.Lock()
 	eng.lastWorld = baseWorld
 	eng.mu.Unlock()
@@ -421,7 +421,7 @@ func TestRedactTitlesToggle(t *testing.T) {
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
 	var logs bytes.Buffer
 	logger := util.NewLoggerWithWriter(util.LevelInfo, &logs)
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
 
 	if err := eng.reconcileAndApply(context.Background()); err != nil {
 		t.Fatalf("reconcileAndApply returned error: %v", err)

--- a/internal/layout/geom_test.go
+++ b/internal/layout/geom_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestSplitSidecarLeft(t *testing.T) {
 	monitor := Rect{X: 0, Y: 0, Width: 1000, Height: 800}
-	_, dock := SplitSidecar(monitor, "left", 25)
+	_, dock := SplitSidecar(monitor, "left", 25, Gaps{})
 	if dock.Width != 250 {
 		t.Fatalf("expected dock width 250, got %v", dock.Width)
 	}
@@ -15,7 +15,7 @@ func TestSplitSidecarLeft(t *testing.T) {
 
 func TestSplitSidecarClampsMinimumWidth(t *testing.T) {
 	monitor := Rect{X: 0, Y: 0, Width: 1000, Height: 800}
-	main, dock := SplitSidecar(monitor, "right", 5)
+	main, dock := SplitSidecar(monitor, "right", 5, Gaps{})
 	if dock.Width != 100 {
 		t.Fatalf("expected dock width to clamp to 100, got %v", dock.Width)
 	}
@@ -24,5 +24,33 @@ func TestSplitSidecarClampsMinimumWidth(t *testing.T) {
 	}
 	if dock.X != 900 {
 		t.Fatalf("expected dock X to start at 900, got %v", dock.X)
+	}
+}
+
+func TestSplitSidecarAppliesGaps(t *testing.T) {
+	monitor := Rect{X: 0, Y: 0, Width: 1000, Height: 800}
+	main, dock := SplitSidecar(monitor, "left", 25, Gaps{Inner: 10, Outer: 20})
+	if dock.X != 20 {
+		t.Fatalf("expected dock X to respect outer gap, got %v", dock.X)
+	}
+	if dock.Width != 237.5 {
+		t.Fatalf("expected dock width 237.5, got %v", dock.Width)
+	}
+	if main.X != 267.5 {
+		t.Fatalf("expected main X 267.5, got %v", main.X)
+	}
+	if main.Height != 760 {
+		t.Fatalf("expected main height 760, got %v", main.Height)
+	}
+}
+
+func TestApproximatelyEqualUsesTolerance(t *testing.T) {
+	a := Rect{Width: 100}
+	b := Rect{Width: 101}
+	if !ApproximatelyEqual(a, b, 1) {
+		t.Fatalf("expected rects to be approximately equal within tolerance")
+	}
+	if ApproximatelyEqual(a, b, 0.5) {
+		t.Fatalf("expected rects to differ when tolerance is too small")
 	}
 }

--- a/internal/rules/actions.go
+++ b/internal/rules/actions.go
@@ -13,11 +13,13 @@ import (
 
 // ActionContext is passed to action planners.
 type ActionContext struct {
-	World             *state.World
-	Logger            *util.Logger
-	RuleName          string
-	ManagedWorkspaces map[int]struct{}
-	AllowUnmanaged    bool
+	World              *state.World
+	Logger             *util.Logger
+	RuleName           string
+	ManagedWorkspaces  map[int]struct{}
+	AllowUnmanaged     bool
+	Gaps               layout.Gaps
+	PlacementTolerance float64
 }
 
 func (ctx ActionContext) workspaceAllowed(id int) bool {
@@ -196,8 +198,8 @@ func (a *SidecarDockAction) Plan(ctx ActionContext) (layout.Plan, error) {
 	if err != nil {
 		return layout.Plan{}, err
 	}
-	_, dock := layout.SplitSidecar(monitor.Rectangle, a.Side, a.WidthPercent)
-	if layout.ApproximatelyEqual(target.Geometry, dock) {
+	_, dock := layout.SplitSidecar(monitor.Rectangle, a.Side, a.WidthPercent, ctx.Gaps)
+	if layout.ApproximatelyEqual(target.Geometry, dock, ctx.PlacementTolerance) {
 		if ctx.Logger != nil {
 			ctx.Logger.Infof("rule %s skipped (idempotent)", ctx.RuleName)
 		}

--- a/internal/rules/actions_test.go
+++ b/internal/rules/actions_test.go
@@ -54,11 +54,11 @@ func TestSidecarDockPlanIdempotentLogs(t *testing.T) {
 		}},
 	}
 
-	_, dock := layout.SplitSidecar(world.Monitors[0].Rectangle, action.Side, action.WidthPercent)
+	_, dock := layout.SplitSidecar(world.Monitors[0].Rectangle, action.Side, action.WidthPercent, layout.Gaps{})
 
 	buf := &bytes.Buffer{}
 	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
-	ctx := ActionContext{World: world, Logger: logger, RuleName: "sidecar"}
+	ctx := ActionContext{World: world, Logger: logger, RuleName: "sidecar", PlacementTolerance: 2, Gaps: layout.Gaps{}}
 
 	plan, err := action.Plan(ctx)
 	if err != nil {
@@ -108,10 +108,12 @@ func TestSidecarDockPlanSkipsOnUnmanagedWorkspace(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
 	ctx := ActionContext{
-		World:             world,
-		Logger:            logger,
-		RuleName:          "sidecar",
-		ManagedWorkspaces: map[int]struct{}{1: {}},
+		World:              world,
+		Logger:             logger,
+		RuleName:           "sidecar",
+		ManagedWorkspaces:  map[int]struct{}{1: {}},
+		PlacementTolerance: 2,
+		Gaps:               layout.Gaps{},
 	}
 
 	plan, err := action.Plan(ctx)
@@ -143,10 +145,12 @@ func TestFullscreenPlanSkipsOnUnmanagedWorkspace(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
 	ctx := ActionContext{
-		World:             world,
-		Logger:            logger,
-		RuleName:          "fullscreen",
-		ManagedWorkspaces: map[int]struct{}{1: {}},
+		World:              world,
+		Logger:             logger,
+		RuleName:           "fullscreen",
+		ManagedWorkspaces:  map[int]struct{}{1: {}},
+		PlacementTolerance: 2,
+		Gaps:               layout.Gaps{},
 	}
 
 	plan, err := action.Plan(ctx)
@@ -176,11 +180,13 @@ func TestFullscreenPlanAllowsWhenOptedIn(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
 	ctx := ActionContext{
-		World:             world,
-		Logger:            logger,
-		RuleName:          "fullscreen",
-		ManagedWorkspaces: map[int]struct{}{1: {}},
-		AllowUnmanaged:    true,
+		World:              world,
+		Logger:             logger,
+		RuleName:           "fullscreen",
+		ManagedWorkspaces:  map[int]struct{}{1: {}},
+		AllowUnmanaged:     true,
+		PlacementTolerance: 2,
+		Gaps:               layout.Gaps{},
 	}
 
 	plan, err := action.Plan(ctx)


### PR DESCRIPTION
## Summary
- add configurable gap and placement tolerance settings to the configuration and propagate them through the engine
- update layout math to respect outer/inner gaps and use the configured tolerance for idempotence checks
- refresh docs, example config, and tests to cover the new behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e18f99d9488325824ccc3b3bd716a3