### PR TITLE
Add matcher profiles to config and action builders

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -8,6 +8,13 @@ gaps:
   inner: 8  # pixels between floating windows
   outer: 20 # pixels around monitor edges
 placementTolerancePx: 2.0 # slack for idempotence checks; set 0 for exact matches
+profiles:
+  commsDock:
+    anyClass: [Slack, discord]
+  designReview:
+    class: Figma
+  fullscreenGames:
+    titleRegex: "(Proton|Steam|Game)"
 modes:
   - name: Coding
     rules:
@@ -24,7 +31,7 @@ modes:
               side: right
               widthPercent: 25 # allowed range: 10-50
               match:
-                anyClass: [Slack, discord]
+                profile: commsDock # reusable match profile defined above
       - name: Float design review on workspace 7
         when:
           all:
@@ -39,7 +46,7 @@ modes:
               side: left
               widthPercent: 30
               match:
-                class: Figma
+                profile: designReview
   - name: Gaming
     rules:
       - name: Fullscreen active game
@@ -58,4 +65,4 @@ modes:
             params:
               target: match
               match:
-                titleRegex: "(Proton|Steam|Game)"
+                profile: fullscreenGames

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestProfilesDuplicateDetection(t *testing.T) {
+	data := []byte(`
+managedWorkspaces: []
+modes:
+  - name: Test
+    rules:
+      - name: Example
+        when:
+          mode: Test
+        actions:
+          - type: layout.fullscreen
+profiles:
+  foo:
+    class: Slack
+  foo:
+    class: Discord
+`)
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err == nil {
+		t.Fatalf("expected duplicate profile error during unmarshal")
+	}
+}
+
+func TestValidateUnknownProfileReference(t *testing.T) {
+	cfg := Config{
+		Modes: []ModeConfig{{
+			Name: "Test",
+			Rules: []RuleConfig{{
+				Name: "Rule",
+				When: PredicateConfig{Mode: "Test"},
+				Actions: []ActionConfig{{
+					Type: "layout.fullscreen",
+					Params: map[string]interface{}{
+						"match": map[string]interface{}{"profile": "missing"},
+					},
+				}},
+			}},
+		}},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected validation error for unknown profile reference")
+	}
+}
+
+func TestValidateProfileDefinition(t *testing.T) {
+	cfg := Config{
+		Profiles: MatcherProfiles{
+			"comms": {AnyClass: []string{"Slack", "Discord"}},
+		},
+		Modes: []ModeConfig{{
+			Name: "Test",
+			Rules: []RuleConfig{{
+				Name: "Rule",
+				When: PredicateConfig{Mode: "Test"},
+				Actions: []ActionConfig{{
+					Type: "layout.fullscreen",
+					Params: map[string]interface{}{
+						"match": map[string]interface{}{"profile": "comms"},
+					},
+				}},
+			}},
+		}},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}

--- a/internal/rules/actions_test.go
+++ b/internal/rules/actions_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hyprpal/hyprpal/internal/config"
 	"github.com/hyprpal/hyprpal/internal/layout"
 	"github.com/hyprpal/hyprpal/internal/state"
 	"github.com/hyprpal/hyprpal/internal/util"
@@ -15,7 +16,7 @@ func TestBuildSidecarDockRejectsNarrowWidth(t *testing.T) {
 		"workspace":    1,
 		"widthPercent": 5,
 		"side":         "left",
-	})
+	}, nil)
 	if err == nil {
 		t.Fatalf("expected error for widthPercent below minimum")
 	}
@@ -26,7 +27,7 @@ func TestBuildSidecarDockRejectsWideWidth(t *testing.T) {
 		"workspace":    1,
 		"widthPercent": 60,
 		"side":         "right",
-	})
+	}, nil)
 	if err == nil {
 		t.Fatalf("expected error for widthPercent above maximum")
 	}
@@ -198,5 +199,24 @@ func TestFullscreenPlanAllowsWhenOptedIn(t *testing.T) {
 	}
 	if strings.Contains(buf.String(), "unmanaged") {
 		t.Fatalf("unexpected unmanaged log when allowUnmanaged is true: %q", buf.String())
+	}
+}
+
+func TestParseClientMatcherProfile(t *testing.T) {
+	profiles := map[string]config.MatcherConfig{
+		"comms": {AnyClass: []string{"Slack", "discord"}},
+	}
+
+	matcher, err := parseClientMatcher(map[string]interface{}{"profile": "comms"}, profiles)
+	if err != nil {
+		t.Fatalf("parseClientMatcher returned error: %v", err)
+	}
+
+	if !matcher(state.Client{Class: "Slack"}) {
+		t.Fatalf("expected matcher to match profile class")
+	}
+
+	if matcher(state.Client{Class: "Firefox"}) {
+		t.Fatalf("expected matcher to reject non-profile class")
 	}
 }

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -38,7 +38,7 @@ func BuildModes(cfg *config.Config) ([]Mode, error) {
 			if err != nil {
 				return nil, fmt.Errorf("rule %s: %w", rc.Name, err)
 			}
-			acts, err := BuildActions(rc.Actions)
+			acts, err := BuildActions(rc.Actions, cfg.Profiles)
 			if err != nil {
 				return nil, fmt.Errorf("rule %s: %w", rc.Name, err)
 			}


### PR DESCRIPTION
## Summary
- add reusable matcher profiles to the configuration model with validation and duplication checks
- resolve matcher profiles when building actions and update the example config to demonstrate usage
- cover matcher profiles with unit tests for config validation and matcher parsing

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1919c908c83258540517a0553de22