### PR TITLE
Add smoke CLI for offline rule evaluation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 BIN_DIR=bin
 HYPRPAL_BIN=$(BIN_DIR)/hyprpal
 HSCTL_BIN=$(BIN_DIR)/hsctl
+SMOKE_BIN=$(BIN_DIR)/smoke
 INSTALL_DIR?=$(HOME)/.local/bin
 
-.PHONY: build run tui install service lint test
+.PHONY: build run tui smoke install service lint test
 
 build:
-	mkdir -p $(BIN_DIR)
-	go build -o $(HYPRPAL_BIN) ./cmd/hyprpal
-	go build -o $(HSCTL_BIN) ./cmd/hsctl
+        mkdir -p $(BIN_DIR)
+        go build -o $(HYPRPAL_BIN) ./cmd/hyprpal
+        go build -o $(HSCTL_BIN) ./cmd/hsctl
+        go build -o $(SMOKE_BIN) ./cmd/smoke
 
 run:
         go run ./cmd/hyprpal --config configs/example.yaml
@@ -16,9 +18,12 @@ run:
 tui:
         go run ./cmd/hsctl tui
 
+smoke:
+        go run ./cmd/smoke --config configs/example.yaml
+
 install:
         mkdir -p $(INSTALL_DIR)
-        GOBIN=$(INSTALL_DIR) go install ./cmd/hyprpal ./cmd/hsctl
+        GOBIN=$(INSTALL_DIR) go install ./cmd/hyprpal ./cmd/hsctl ./cmd/smoke
 
 service:
 	systemctl --user daemon-reload

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@
    make run
    ```
    Use `--dry-run` to preview dispatches without affecting windows. Pass `--dispatch=hyprctl` to force shelling out to `hyprctl` when the socket strategy is undesirable or unavailable.
+5. Need a quick snapshot without touching Hyprland? Use the smoke CLI to load the config, capture the current world, and preview the plan without dispatching anything:
+   ```bash
+   make smoke
+   ```
+   Override the mode or config path via `--mode`/`--config` when auditioning alternative setups.
 5. Follow logs while iterating (see [Troubleshooting & Logging](#troubleshooting--logging) for trace mode tips):
     ```bash
     journalctl --user -fu hyprpal
@@ -63,6 +68,18 @@ hsctl plan --explain
 ```
 
 When no actions are queued, `hsctl` prints `No pending actions`.
+
+## `smoke` world snapshot CLI
+
+`cmd/smoke` is a standalone helper that bootstraps the rule engine with a no-op dispatcher. It loads your configuration, captures a one-off world snapshot with the regular Hyprland queries, prints both structures, and evaluates the active mode to show the pending dispatches alongside the rule that generated them. Use it when iterating on YAML changes outside of Hyprland or when you want to verify predicate logic without letting the daemon mutate windows.
+
+Typical usage while editing a config:
+
+```bash
+go run ./cmd/smoke --config ~/.config/hyprpal/config.yaml --mode Coding --explain
+```
+
+The `--explain` flag (enabled by default) annotates each dispatch with its `mode:rule` source, mirroring `hsctl plan --explain`. Predicate traces are also printed so you can understand why a rule matched or skipped.
 
 ## Configuration
 
@@ -147,6 +164,7 @@ Pair `--log-level=trace` with `--dry-run` to audition rules without moving windo
 
 - `make build` – compile to `bin/hyprpal`.
 - `make run` – run the daemon against `configs/example.yaml`.
+- `make smoke` – run the smoke CLI to inspect the current world snapshot against `configs/example.yaml`.
 - `make install` – install the binary to `~/.local/bin` (override with `INSTALL_DIR=...`).
 - `make service` – reload and start the user service.
 - `make lint` – run `go vet` plus a `gofmt` check.

--- a/cmd/smoke/main.go
+++ b/cmd/smoke/main.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/hyprpal/hyprpal/internal/config"
+	"github.com/hyprpal/hyprpal/internal/engine"
+	"github.com/hyprpal/hyprpal/internal/ipc"
+	"github.com/hyprpal/hyprpal/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/rules"
+	"github.com/hyprpal/hyprpal/internal/state"
+	"github.com/hyprpal/hyprpal/internal/util"
+)
+
+type smokeClient struct {
+	*ipc.Client
+}
+
+func (c *smokeClient) Dispatch(args ...string) error {
+	return nil
+}
+
+func (c *smokeClient) DispatchBatch(commands [][]string) error {
+	return nil
+}
+
+func main() {
+	home, _ := os.UserHomeDir()
+	defaultConfig := filepath.Join(home, ".config", "hyprpal", "config.yaml")
+
+	cfgPath := flag.String("config", defaultConfig, "path to YAML config")
+	logLevel := flag.String("log-level", "info", "log level (trace|debug|info|warn|error)")
+	mode := flag.String("mode", "", "mode to evaluate (defaults to config's first mode)")
+	explain := flag.Bool("explain", true, "include rule reasons with planned commands")
+	flag.Parse()
+
+	logger := util.NewLogger(util.ParseLogLevel(*logLevel))
+
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		exitErr(fmt.Errorf("load config: %w", err))
+	}
+
+	modes, err := rules.BuildModes(cfg)
+	if err != nil {
+		exitErr(fmt.Errorf("compile rules: %w", err))
+	}
+
+	client := &smokeClient{Client: ipc.NewClient()}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	world, err := state.NewWorld(ctx, client)
+	if err != nil {
+		exitErr(fmt.Errorf("build world: %w", err))
+	}
+
+	fmt.Printf("Loaded config from %s\n", *cfgPath)
+	fmt.Println("\n=== Configuration ===")
+	if err := marshalYAML(cfg); err != nil {
+		logger.Warnf("failed to print config: %v", err)
+	}
+
+	fmt.Println("\n=== World Snapshot ===")
+	if err := marshalJSON(world); err != nil {
+		logger.Warnf("failed to print world snapshot: %v", err)
+	}
+
+	eng := engine.New(client, logger, modes, true, cfg.RedactTitles, layout.Gaps{
+		Inner: cfg.Gaps.Inner,
+		Outer: cfg.Gaps.Outer,
+	}, cfg.PlacementTolerancePx)
+
+	if *mode != "" {
+		if err := eng.SetMode(*mode); err != nil {
+			logger.Warnf("unable to set mode %q: %v", *mode, err)
+		}
+	}
+
+	fmt.Printf("\nEvaluating mode: %s\n", eng.ActiveMode())
+	commands, err := eng.PreviewPlan(ctx, *explain)
+	if err != nil {
+		exitErr(fmt.Errorf("preview plan: %w", err))
+	}
+
+	if len(commands) == 0 {
+		fmt.Println("\nNo planned commands for current snapshot.")
+	} else {
+		fmt.Println("\n=== Planned Commands ===")
+		for _, cmd := range commands {
+			fmt.Printf("dispatch: %s\n", formatCommand(cmd.Dispatch))
+			if cmd.Reason != "" {
+				fmt.Printf("  reason: %s\n", cmd.Reason)
+			}
+		}
+	}
+
+	checks := eng.RuleCheckHistory()
+	if len(checks) > 0 {
+		fmt.Println("\n=== Rule Evaluation Checks ===")
+		for _, check := range checks {
+			status := "skipped"
+			if check.Matched {
+				status = "matched"
+			}
+			fmt.Printf("[%s] %s → %s", check.Timestamp.Format(time.RFC3339), check.Rule, status)
+			if check.Reason != "" {
+				fmt.Printf(" (%s)", check.Reason)
+			}
+			fmt.Println()
+			if check.Predicate != nil {
+				if err := marshalJSON(check.Predicate); err != nil {
+					logger.Warnf("failed to print predicate trace for %s: %v", check.Rule, err)
+				}
+			}
+		}
+	}
+}
+
+func exitErr(err error) {
+	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	os.Exit(1)
+}
+
+func marshalYAML(v any) error {
+	enc := yaml.NewEncoder(os.Stdout)
+	enc.SetIndent(2)
+	defer enc.Close()
+	return enc.Encode(v)
+}
+
+func marshalJSON(v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func formatCommand(parts []string) string {
+	return strings.Join(parts, " ")
+}


### PR DESCRIPTION
## Summary
- add a `smoke` command that loads config/world snapshots and previews plans with a no-op dispatcher
- wire the command into the Makefile build/install/run targets
- document the smoke CLI workflow in the README

## Acceptance Criteria
- [x] Smoke CLI loads configuration and Hyprland world snapshots using existing helpers
- [x] Rule evaluation reuses the engine with dispatch stubbed out for planning only
- [x] Build tooling and docs mention how to build/run the smoke command

## Testing
- [x] `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e19380324c83259176bca451967824