### PR TITLE
Rename placement tolerance config to tolerancePx

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ managedWorkspaces:
 gaps:
   inner: 8
   outer: 20
-placementTolerancePx: 2
+tolerancePx: 2
 modes:
   - name: Coding
     rules:
@@ -121,7 +121,7 @@ modes:
               target: active
 ```
 
-Place the configuration at `~/.config/hyprpal/config.yaml` to align with the provided systemd unit. `managedWorkspaces` scopes hyprpal’s actions to the listed workspace IDs by default—rules will be skipped elsewhere unless they set `allowUnmanaged: true`. Leaving the list empty allows every workspace to be managed. Use the root-level `gaps` block to mirror your Hyprland gap settings (outer gap trims the monitor rectangle, inner gap is placed between floated windows). `placementTolerancePx` controls how much wiggle room hyprpal allows when comparing rectangles for idempotence; keep it aligned with Hyprland’s rounding behavior (default `2px`, or `0` for exact matches). `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. The daemon automatically reloads when this file changes and still honors `SIGHUP` (e.g. `systemctl --user reload hyprpal`) for manual reloads. Runtime flags such as `--dispatch=socket|hyprctl`, `--dry-run`, `--log-level`, and `--mode` let you adjust behavior without editing the config file.
+Place the configuration at `~/.config/hyprpal/config.yaml` to align with the provided systemd unit. `managedWorkspaces` scopes hyprpal’s actions to the listed workspace IDs by default—rules will be skipped elsewhere unless they set `allowUnmanaged: true`. Leaving the list empty allows every workspace to be managed. Use the root-level `gaps` block to mirror your Hyprland gap settings (outer gap trims the monitor rectangle, inner gap is placed between floated windows). `tolerancePx` controls how much wiggle room hyprpal allows when comparing rectangles for idempotence; keep it aligned with Hyprland’s rounding behavior (default `2px`, or `0` for exact matches). `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. The daemon automatically reloads when this file changes and still honors `SIGHUP` (e.g. `systemctl --user reload hyprpal`) for manual reloads. Runtime flags such as `--dispatch=socket|hyprctl`, `--dry-run`, `--log-level`, and `--mode` let you adjust behavior without editing the config file.
 
 ### Adjust presets for your setup
 

--- a/cmd/hyprpal/main.go
+++ b/cmd/hyprpal/main.go
@@ -81,7 +81,7 @@ func main() {
 	eng := engine.New(hypr, logger, modes, *dryRun, cfg.RedactTitles, layout.Gaps{
 		Inner: cfg.Gaps.Inner,
 		Outer: cfg.Gaps.Outer,
-	}, cfg.PlacementTolerancePx)
+	}, cfg.TolerancePx)
 	if *startMode != "" {
 		if err := eng.SetMode(*startMode); err != nil {
 			logger.Warnf("failed to set mode %s: %v", *startMode, err)
@@ -106,7 +106,7 @@ func main() {
 		eng.SetLayoutParameters(layout.Gaps{
 			Inner: cfg.Gaps.Inner,
 			Outer: cfg.Gaps.Outer,
-		}, cfg.PlacementTolerancePx)
+		}, cfg.TolerancePx)
 		if err := eng.Reconcile(ctx); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil

--- a/cmd/smoke/main.go
+++ b/cmd/smoke/main.go
@@ -79,7 +79,7 @@ func main() {
 	eng := engine.New(client, logger, modes, true, cfg.RedactTitles, layout.Gaps{
 		Inner: cfg.Gaps.Inner,
 		Outer: cfg.Gaps.Outer,
-	}, cfg.PlacementTolerancePx)
+	}, cfg.TolerancePx)
 
 	if *mode != "" {
 		if err := eng.SetMode(*mode); err != nil {

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -7,7 +7,7 @@ redactTitles: false # set to true to hide client titles from logs and control AP
 gaps:
   inner: 8  # pixels between floating windows
   outer: 20 # pixels around monitor edges
-placementTolerancePx: 2.0 # slack for idempotence checks; set 0 for exact matches
+tolerancePx: 2.0 # slack for idempotence checks; set 0 for exact matches
 profiles:
   commsDock:
     anyClass: [Slack, discord]

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,3 +76,27 @@ func TestValidateProfileDefinition(t *testing.T) {
 		t.Fatalf("unexpected validation error: %v", err)
 	}
 }
+
+func TestConfigUnmarshalToleranceAliases(t *testing.T) {
+	t.Run("tolerancePx", func(t *testing.T) {
+		data := []byte(`tolerancePx: 3.5`)
+		var cfg Config
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.TolerancePx != 3.5 {
+			t.Fatalf("expected TolerancePx to be 3.5, got %v", cfg.TolerancePx)
+		}
+	})
+
+	t.Run("placementTolerancePx", func(t *testing.T) {
+		data := []byte(`placementTolerancePx: 1.25`)
+		var cfg Config
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.TolerancePx != 1.25 {
+			t.Fatalf("expected legacy placementTolerancePx to populate TolerancePx, got %v", cfg.TolerancePx)
+		}
+	})
+}

--- a/internal/rules/actions.go
+++ b/internal/rules/actions.go
@@ -13,13 +13,13 @@ import (
 
 // ActionContext is passed to action planners.
 type ActionContext struct {
-	World              *state.World
-	Logger             *util.Logger
-	RuleName           string
-	ManagedWorkspaces  map[int]struct{}
-	AllowUnmanaged     bool
-	Gaps               layout.Gaps
-	PlacementTolerance float64
+	World             *state.World
+	Logger            *util.Logger
+	RuleName          string
+	ManagedWorkspaces map[int]struct{}
+	AllowUnmanaged    bool
+	Gaps              layout.Gaps
+	TolerancePx       float64
 }
 
 func (ctx ActionContext) workspaceAllowed(id int) bool {
@@ -252,7 +252,7 @@ func (a *SidecarDockAction) Plan(ctx ActionContext) (layout.Plan, error) {
 		return layout.Plan{}, err
 	}
 	_, dock := layout.SplitSidecar(monitor.Rectangle, a.Side, a.WidthPercent, ctx.Gaps)
-	if layout.ApproximatelyEqual(target.Geometry, dock, ctx.PlacementTolerance) {
+	if layout.ApproximatelyEqual(target.Geometry, dock, ctx.TolerancePx) {
 		if ctx.Logger != nil {
 			ctx.Logger.Infof("rule %s skipped (idempotent)", ctx.RuleName)
 		}

--- a/internal/rules/actions_test.go
+++ b/internal/rules/actions_test.go
@@ -59,7 +59,7 @@ func TestSidecarDockPlanIdempotentLogs(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
-	ctx := ActionContext{World: world, Logger: logger, RuleName: "sidecar", PlacementTolerance: 2, Gaps: layout.Gaps{}}
+	ctx := ActionContext{World: world, Logger: logger, RuleName: "sidecar", TolerancePx: 2, Gaps: layout.Gaps{}}
 
 	plan, err := action.Plan(ctx)
 	if err != nil {
@@ -109,12 +109,12 @@ func TestSidecarDockPlanSkipsOnUnmanagedWorkspace(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
 	ctx := ActionContext{
-		World:              world,
-		Logger:             logger,
-		RuleName:           "sidecar",
-		ManagedWorkspaces:  map[int]struct{}{1: {}},
-		PlacementTolerance: 2,
-		Gaps:               layout.Gaps{},
+		World:             world,
+		Logger:            logger,
+		RuleName:          "sidecar",
+		ManagedWorkspaces: map[int]struct{}{1: {}},
+		TolerancePx:       2,
+		Gaps:              layout.Gaps{},
 	}
 
 	plan, err := action.Plan(ctx)
@@ -146,12 +146,12 @@ func TestFullscreenPlanSkipsOnUnmanagedWorkspace(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
 	ctx := ActionContext{
-		World:              world,
-		Logger:             logger,
-		RuleName:           "fullscreen",
-		ManagedWorkspaces:  map[int]struct{}{1: {}},
-		PlacementTolerance: 2,
-		Gaps:               layout.Gaps{},
+		World:             world,
+		Logger:            logger,
+		RuleName:          "fullscreen",
+		ManagedWorkspaces: map[int]struct{}{1: {}},
+		TolerancePx:       2,
+		Gaps:              layout.Gaps{},
 	}
 
 	plan, err := action.Plan(ctx)
@@ -181,13 +181,13 @@ func TestFullscreenPlanAllowsWhenOptedIn(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := util.NewLoggerWithWriter(util.LevelInfo, buf)
 	ctx := ActionContext{
-		World:              world,
-		Logger:             logger,
-		RuleName:           "fullscreen",
-		ManagedWorkspaces:  map[int]struct{}{1: {}},
-		AllowUnmanaged:     true,
-		PlacementTolerance: 2,
-		Gaps:               layout.Gaps{},
+		World:             world,
+		Logger:            logger,
+		RuleName:          "fullscreen",
+		ManagedWorkspaces: map[int]struct{}{1: {}},
+		AllowUnmanaged:    true,
+		TolerancePx:       2,
+		Gaps:              layout.Gaps{},
 	}
 
 	plan, err := action.Plan(ctx)


### PR DESCRIPTION
## Summary
- expose the root-level `tolerancePx` configuration field while accepting the legacy `placementTolerancePx` key
- propagate the renamed tolerance through the engine, actions, and command wiring so idempotence checks read the new field
- refresh documentation, config fixtures, and tests to reference `tolerancePx`

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1ac832b8c8325ba49419f76ab666e