### PR TITLE
Add support for monitor reserved safe zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ modes:
 
 Place the configuration at `~/.config/hyprpal/config.yaml` to align with the provided systemd unit. `managedWorkspaces` scopes hyprpal’s actions to the listed workspace IDs by default—rules will be skipped elsewhere unless they set `allowUnmanaged: true`. Leaving the list empty allows every workspace to be managed. Use the root-level `gaps` block to mirror your Hyprland gap settings (outer gap trims the monitor rectangle, inner gap is placed between floated windows). `placementTolerancePx` controls how much wiggle room hyprpal allows when comparing rectangles for idempotence; keep it aligned with Hyprland’s rounding behavior (default `2px`, or `0` for exact matches). `layout.sidecarDock` enforces a width between 10–50% of the monitor; values below 10% are rejected during config loading. The daemon automatically reloads when this file changes and still honors `SIGHUP` (e.g. `systemctl --user reload hyprpal`) for manual reloads. Runtime flags such as `--dispatch=socket|hyprctl`, `--dry-run`, `--log-level`, and `--mode` let you adjust behavior without editing the config file.
 
+Need to keep space for a Waybar panel or a capture-card overlay? Declare manual safe zones with `monitors.<name>.reserved`. Hyprpal subtracts Hyprland’s `reserved` array first, then applies any overrides you specify so layouts never overlap the blocked area:
+
+```yaml
+monitors:
+  HDMI-A-1:
+    reserved:
+      top: 48    # pixels kept free above the usable monitor area
+      right: 0   # omit keys you don’t need—unspecified sides use Hyprland’s values
+      bottom: 0
+      left: 160 # e.g. leave room for a hardware capture preview
+```
+
+Only the sides you specify are overridden; omitted values continue using Hyprland’s live data so on-dock panels keep working without duplication.
+
 ### Adjust presets for your setup
 
 When reusing a preset, update monitor names, workspace IDs, and application classes to match your Hyprland environment. The accompanying READMEs in each [`examples/`](./examples/) preset (for instance, [`examples/dual-monitor/README.md`](./examples/dual-monitor/README.md)) call out the expected monitor names and client classes so you know what to tweak before copying the config. If you adopt multiple presets, consult each README to understand the assumptions around docking widths, preferred workspaces, and optional dependencies.

--- a/cmd/hyprpal/main.go
+++ b/cmd/hyprpal/main.go
@@ -81,7 +81,7 @@ func main() {
 	eng := engine.New(hypr, logger, modes, *dryRun, cfg.RedactTitles, layout.Gaps{
 		Inner: cfg.Gaps.Inner,
 		Outer: cfg.Gaps.Outer,
-	}, cfg.PlacementTolerancePx)
+	}, cfg.PlacementTolerancePx, cfg.MonitorReservedOverrides())
 	if *startMode != "" {
 		if err := eng.SetMode(*startMode); err != nil {
 			logger.Warnf("failed to set mode %s: %v", *startMode, err)
@@ -106,7 +106,7 @@ func main() {
 		eng.SetLayoutParameters(layout.Gaps{
 			Inner: cfg.Gaps.Inner,
 			Outer: cfg.Gaps.Outer,
-		}, cfg.PlacementTolerancePx)
+		}, cfg.PlacementTolerancePx, cfg.MonitorReservedOverrides())
 		if err := eng.Reconcile(ctx); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil

--- a/cmd/smoke/main.go
+++ b/cmd/smoke/main.go
@@ -79,7 +79,7 @@ func main() {
 	eng := engine.New(client, logger, modes, true, cfg.RedactTitles, layout.Gaps{
 		Inner: cfg.Gaps.Inner,
 		Outer: cfg.Gaps.Outer,
-	}, cfg.PlacementTolerancePx)
+	}, cfg.PlacementTolerancePx, cfg.MonitorReservedOverrides())
 
 	if *mode != "" {
 		if err := eng.SetMode(*mode); err != nil {

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -7,6 +7,14 @@ redactTitles: false # set to true to hide client titles from logs and control AP
 gaps:
   inner: 8  # pixels between floating windows
   outer: 20 # pixels around monitor edges
+monitors:
+  # Optional per-monitor safe zones (overrides Hyprland's reserved values).
+  DP-1:
+    reserved:
+      top: 48    # keep room for a panel or screen recorder overlay
+      bottom: 0
+      left: 0
+      right: 0
 placementTolerancePx: 2.0 # slack for idempotence checks; set 0 for exact matches
 profiles:
   commsDock:

--- a/examples/streaming.yaml
+++ b/examples/streaming.yaml
@@ -3,6 +3,13 @@ managedWorkspaces:
   - 7
   - 8
   - 9
+monitors:
+  HDMI-A-1:
+    reserved:
+      top: 64   # keep status bar visible above chat dock
+      right: 0
+      bottom: 0
+      left: 0
 modes:
   - name: Streaming
     rules:

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -101,7 +101,7 @@ func TestReconcileAndApplyLogsDebounceSkip(t *testing.T) {
 			Debounce: time.Second,
 		}},
 	}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2, nil)
 	key := mode.Name + ":" + mode.Rules[0].Name
 	eng.debounce[key] = time.Now()
 
@@ -133,7 +133,7 @@ func TestReconcileSkipsRulesDuringCooldown(t *testing.T) {
 		Actions: []rules.Action{stubAction{plan: actPlan}},
 	}
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2, nil)
 
 	if err := eng.reconcileAndApply(context.Background()); err != nil {
 		t.Fatalf("first reconcileAndApply returned error: %v", err)
@@ -172,7 +172,7 @@ func TestReconcileUsesBatchDispatcherWhenAvailable(t *testing.T) {
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
 	var logs bytes.Buffer
 	logger := util.NewLoggerWithWriter(util.LevelInfo, &logs)
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2, nil)
 
 	if err := eng.reconcileAndApply(context.Background()); err != nil {
 		t.Fatalf("reconcileAndApply returned error: %v", err)
@@ -203,7 +203,7 @@ func TestRuleExecutionTrackingAllowsNormalFlow(t *testing.T) {
 		Actions: []rules.Action{stubAction{plan: plan}},
 	}
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2, nil)
 
 	if err := eng.reconcileAndApply(context.Background()); err != nil {
 		t.Fatalf("reconcileAndApply returned error: %v", err)
@@ -231,7 +231,7 @@ func TestRuleExecutionTrackingBelowThreshold(t *testing.T) {
 		Actions: []rules.Action{stubAction{plan: plan}},
 	}
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2, nil)
 	key := mode.Name + ":" + rule.Name
 
 	for i := 0; i < ruleBurstThreshold; i++ {
@@ -264,7 +264,7 @@ func TestRuleExecutionTrackingExceedsThreshold(t *testing.T) {
 		Actions: []rules.Action{stubAction{plan: plan}},
 	}
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2, nil)
 	key := mode.Name + ":" + rule.Name
 
 	for i := 0; i < ruleBurstThreshold; i++ {
@@ -321,7 +321,7 @@ func TestTraceLoggingDryRunSequence(t *testing.T) {
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
 	var logs bytes.Buffer
 	logger := util.NewLoggerWithWriter(util.LevelTrace, &logs)
-	eng := New(hypr, logger, []rules.Mode{mode}, true, false, layout.Gaps{}, 2)
+	eng := New(hypr, logger, []rules.Mode{mode}, true, false, layout.Gaps{}, 2, nil)
 	eng.mu.Lock()
 	eng.lastWorld = baseWorld
 	eng.mu.Unlock()
@@ -421,7 +421,7 @@ func TestRedactTitlesToggle(t *testing.T) {
 	mode := rules.Mode{Name: "Focus", Rules: []rules.Rule{rule}}
 	var logs bytes.Buffer
 	logger := util.NewLoggerWithWriter(util.LevelInfo, &logs)
-	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2)
+	eng := New(hypr, logger, []rules.Mode{mode}, false, false, layout.Gaps{}, 2, nil)
 
 	if err := eng.reconcileAndApply(context.Background()); err != nil {
 		t.Fatalf("reconcileAndApply returned error: %v", err)

--- a/internal/ipc/hyprctl.go
+++ b/internal/ipc/hyprctl.go
@@ -133,12 +133,13 @@ func (c *Client) ListMonitors(ctx context.Context) ([]state.Monitor, error) {
 		return nil, err
 	}
 	var raw []struct {
-		ID              int     `json:"id"`
-		Name            string  `json:"name"`
-		X               float64 `json:"x"`
-		Y               float64 `json:"y"`
-		Width           float64 `json:"width"`
-		Height          float64 `json:"height"`
+		ID              int       `json:"id"`
+		Name            string    `json:"name"`
+		X               float64   `json:"x"`
+		Y               float64   `json:"y"`
+		Width           float64   `json:"width"`
+		Height          float64   `json:"height"`
+		Reserved        []float64 `json:"reserved"`
 		ActiveWorkspace struct {
 			ID int `json:"id"`
 		} `json:"activeWorkspace"`
@@ -151,10 +152,18 @@ func (c *Client) ListMonitors(ctx context.Context) ([]state.Monitor, error) {
 	}
 	monitors := make([]state.Monitor, 0, len(raw))
 	for _, m := range raw {
+		reserved := layout.Insets{}
+		if len(m.Reserved) == 4 {
+			reserved.Top = m.Reserved[0]
+			reserved.Bottom = m.Reserved[1]
+			reserved.Left = m.Reserved[2]
+			reserved.Right = m.Reserved[3]
+		}
 		monitors = append(monitors, state.Monitor{
 			ID:                 m.ID,
 			Name:               m.Name,
 			Rectangle:          layout.Rect{X: m.X, Y: m.Y, Width: m.Width, Height: m.Height},
+			Reserved:           reserved,
 			ActiveWorkspaceID:  m.ActiveWorkspace.ID,
 			FocusedWorkspaceID: m.FocusedWorkspace.ID,
 		})

--- a/internal/state/world.go
+++ b/internal/state/world.go
@@ -33,6 +33,7 @@ type Monitor struct {
 	ID                 int
 	Name               string
 	Rectangle          layout.Rect
+	Reserved           layout.Insets
 	ActiveWorkspaceID  int
 	FocusedWorkspaceID int
 }


### PR DESCRIPTION
## Summary
- track compositor-provided monitor reserved insets in state and IPC parsing
- allow manual reserved overrides via `monitors.<name>.reserved.*` config and flow them through the engine
- update layout math, rules, and docs so sidecar docks honor compositor/manual safe areas

## Acceptance Criteria
- [x] Reserved inset data from Hyprland is captured in state and clone operations
- [x] Layout planning respects compositor and manual safe areas before applying gaps
- [x] Documentation and examples explain how to configure manual reserved zones

## How to test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e1ae58b12c8325b1d6de4c2bdbaa8d