### PR TITLE
Handle tolerancePx default only when unspecified

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	TolerancePx       float64                  `yaml:"tolerancePx"`
 	Profiles          MatcherProfiles          `yaml:"profiles"`
 	ManualReserved    map[string]layout.Insets `yaml:"manualReserved"`
+	toleranceSet      bool                     `yaml:"-"`
 }
 
 // UnmarshalYAML handles deprecated fields while decoding configuration files.
@@ -48,10 +49,13 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	switch {
 	case raw.TolerancePx != nil:
 		c.TolerancePx = *raw.TolerancePx
+		c.toleranceSet = true
 	case raw.LegacyTolerancePx != nil:
 		c.TolerancePx = *raw.LegacyTolerancePx
+		c.toleranceSet = true
 	default:
 		c.TolerancePx = 0
+		c.toleranceSet = false
 	}
 
 	return nil
@@ -157,8 +161,9 @@ func Load(path string) (*Config, error) {
 }
 
 func (c *Config) applyDefaults() {
-	if c.TolerancePx == 0 {
+	if !c.toleranceSet {
 		c.TolerancePx = 2.0
+		c.toleranceSet = true
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,4 +122,27 @@ func TestConfigUnmarshalToleranceAliases(t *testing.T) {
 			t.Fatalf("expected legacy placementTolerancePx to populate TolerancePx, got %v", cfg.TolerancePx)
 		}
 	})
+
+	t.Run("defaultWhenAbsent", func(t *testing.T) {
+		var cfg Config
+		if err := yaml.Unmarshal([]byte(`{}`), &cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg.applyDefaults()
+		if cfg.TolerancePx != 2 {
+			t.Fatalf("expected default tolerancePx of 2, got %v", cfg.TolerancePx)
+		}
+	})
+
+	t.Run("explicitZeroPreserved", func(t *testing.T) {
+		data := []byte(`tolerancePx: 0`)
+		var cfg Config
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg.applyDefaults()
+		if cfg.TolerancePx != 0 {
+			t.Fatalf("expected explicit tolerancePx of 0 to be preserved, got %v", cfg.TolerancePx)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- track when tolerancePx (or its legacy alias) is provided during config unmarshalling
- only fall back to the 2px default when the value is absent so explicit zero survives defaults
- extend config tests to cover the defaulting behavior and explicit zero to match the docs

## Acceptance Criteria
- [x] Tolerance defaulting matches documentation and preserves explicit zero
- [x] Unit tests updated to exercise new behavior

## How to Test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e1c71f2084832588ca4b19be437337