### PR TITLE
docs: document layout grid coding preset

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -23,38 +23,47 @@ profiles:
     class: Figma
   fullscreenGames:
     titleRegex: "(Proton|Steam|Game)"
+  codingEditor:
+    class: code
+  codingTerminal:
+    anyClass: [Alacritty, kitty]
+  codingReference:
+    anyClass: [firefox, brave-browser]
 modes:
   - name: Coding
     rules:
-      - name: Dock comms on workspace 3
+      - name: Arrange coding grid on workspace 3
         when:
           all:
             - mode: Coding
             - workspace.id: 3
-            - apps.present: [Slack, discord]
         actions:
-          - type: layout.sidecarDock
+          - type: layout.grid
             params:
               workspace: 3
-              side: right
-              widthPercent: 25 # allowed range: 10-50
-              match:
-                profile: commsDock # reusable match profile defined above
-      - name: Float design review on workspace 7
-        when:
-          all:
-            - mode: Coding
-            - workspace.id: 7
-            - app.class: Figma
-        mutateUnmanaged: true # opt this rule into unmanaged workspace 7
-        actions:
-          - type: layout.sidecarDock
-            params:
-              workspace: 7
-              side: left
-              widthPercent: 30
-              match:
-                profile: designReview
+              # Give the primary column twice the weight of the secondary column
+              colWeights: [2, 1]
+              # Favor vertical space for the upper row while keeping room for reference docs
+              rowWeights: [3, 2]
+              slots:
+                - name: editor
+                  row: 0
+                  col: 0
+                  # Span both rows so the IDE owns the full-height primary column
+                  span:
+                    rows: 2
+                  match:
+                    profile: codingEditor
+                - name: terminal
+                  row: 0
+                  col: 1
+                  match:
+                    profile: codingTerminal
+                - name: reference
+                  row: 1
+                  col: 1
+                  match:
+                    profile: codingReference
   - name: Gaming
     rules:
       - name: Fullscreen active game

--- a/examples/coding.md
+++ b/examples/coding.md
@@ -2,14 +2,23 @@
 
 This preset assumes a dual-monitor workstation with the primary development monitor exposed as `DP-1` and a secondary communications monitor exposed as `HDMI-A-1`.
 
+## Grid layout structure
+- Workspace `1` uses `layout.grid` to keep the IDE focused:
+  - `colWeights: [2, 1]` doubles the editor column compared to the utility column.
+  - `rowWeights: [3, 2]` keeps the top row dominant while reserving space for documentation panes.
+  - Slot `editor` spans two rows (rows `0-1`) so the IDE keeps full height.
+  - Slot `terminal` lives on row `0`, column `1` for quick command access.
+  - Slot `docs` occupies row `1`, column `1` for browsers, notes, or API references.
+  - Adjust slot `match` clauses to map the layout to your application classes.
+
 ## Application targets
 - IDE window with class `code` (Visual Studio Code) on workspace `1`
 - Terminal windows with class `Alacritty` to dock alongside the IDE
-- Communication clients with classes `Slack` or `discord` on workspace `3`
+- Browser or documentation windows such as `firefox` or `brave-browser` for the `docs` slot
 
 ## Workspace layout assumptions
 - Workspace `1` is your main development surface on `DP-1`
 - Workspace `2` is left unmanaged for ad-hoc windows
-- Workspace `3` lives on `HDMI-A-1` for persistent comms
+- Workspace `3` can be repurposed for persistent communications or other layouts as needed
 
 Adjust monitor names, classes, or workspace IDs to match your Hyprland environment.

--- a/examples/coding.yaml
+++ b/examples/coding.yaml
@@ -6,44 +6,36 @@ managedWorkspaces:
 modes:
   - name: Coding
     rules:
-      - name: Keep IDE primary on workspace 1
+      - name: Arrange workspace 1 as a coding grid
         when:
           all:
             - mode: Coding
             - workspace.id: 1
             - monitor.name: DP-1
-            - app.class: code
         actions:
-          - type: layout.fullscreen
-            params:
-              target: active
-      - name: Dock terminal companion
-        when:
-          all:
-            - mode: Coding
-            - workspace.id: 1
-            - monitor.name: DP-1
-            - apps.present: [Alacritty]
-        actions:
-          - type: layout.sidecarDock
+          - type: layout.grid
             params:
               workspace: 1
-              side: left
-              widthPercent: 30
-              match:
-                class: Alacritty
-      - name: Pin communications on workspace 3
-        when:
-          all:
-            - mode: Coding
-            - workspace.id: 3
-            - monitor.name: HDMI-A-1
-            - apps.present: [Slack, discord]
-        actions:
-          - type: layout.sidecarDock
-            params:
-              workspace: 3
-              side: right
-              widthPercent: 25
-              match:
-                anyClass: [Slack, discord]
+              # Primary column gets twice the width of the utility column
+              colWeights: [2, 1]
+              # Upper row is weighted for the editor/terminal stack, lower row keeps context panes visible
+              rowWeights: [3, 2]
+              slots:
+                - name: editor
+                  row: 0
+                  col: 0
+                  # Span both rows so the IDE keeps full height when terminals or docs appear
+                  span:
+                    rows: 2
+                  match:
+                    class: code
+                - name: terminal
+                  row: 0
+                  col: 1
+                  match:
+                    anyClass: [Alacritty, kitty]
+                - name: docs
+                  row: 1
+                  col: 1
+                  match:
+                    anyClass: [firefox, "Google-chrome", brave-browser]


### PR DESCRIPTION
## Summary
- replace the Coding mode example with a layout.grid workspace definition that demonstrates column/row weighting and a multi-row editor slot
- update the coding preset YAML to mirror the grid example and annotate slot names, spans, and weight choices
- refresh the coding preset documentation to explain the new grid slot expectations for users

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1de360e6083259ac9083d66cc49ff