### PR TITLE
Improve config reload error reporting

### DIFF
--- a/cmd/hyprpal/reloader.go
+++ b/cmd/hyprpal/reloader.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/hyprpal/hyprpal/internal/config"
+	"github.com/hyprpal/hyprpal/internal/engine"
+	"github.com/hyprpal/hyprpal/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/rules"
+	"github.com/hyprpal/hyprpal/internal/util"
+)
+
+type configReloader struct {
+	path           string
+	logger         *util.Logger
+	engine         *engine.Engine
+	lastConfig     *config.Config
+	lastSerialized []byte
+}
+
+func newConfigReloader(path string, logger *util.Logger, eng *engine.Engine, cfg *config.Config, serialized []byte) *configReloader {
+	return &configReloader{
+		path:           path,
+		logger:         logger,
+		engine:         eng,
+		lastConfig:     cfg,
+		lastSerialized: append([]byte(nil), serialized...),
+	}
+}
+
+func (r *configReloader) Reload(ctx context.Context, reason string) error {
+	r.logger.Infof("%s, reloading config", reason)
+	raw, err := os.ReadFile(r.path)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+	cfg, err := config.Parse(raw)
+	if err != nil {
+		r.logDiff(raw)
+		return err
+	}
+	if err := cfg.Validate(); err != nil {
+		r.logDiff(raw)
+		return err
+	}
+	modes, err := rules.BuildModes(cfg)
+	if err != nil {
+		r.logDiff(raw)
+		return fmt.Errorf("compile rules: %w", err)
+	}
+
+	r.engine.ReloadModes(modes)
+	r.engine.SetRedactTitles(cfg.RedactTitles)
+	r.engine.SetLayoutParameters(layout.Gaps{
+		Inner: cfg.Gaps.Inner,
+		Outer: cfg.Gaps.Outer,
+	}, cfg.TolerancePx)
+	r.engine.SetManualReserved(cfg.ManualReserved)
+	if err := r.engine.Reconcile(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return fmt.Errorf("reconcile after reload: %w", err)
+	}
+
+	r.lastConfig = cfg
+	r.lastSerialized = append([]byte(nil), raw...)
+	return nil
+}
+
+func (r *configReloader) logDiff(current []byte) {
+	diff := config.DiffSerialized(r.lastSerialized, current)
+	if diff == "" {
+		r.logger.Warnf("config change rejected; unable to compute diff vs last valid config")
+		return
+	}
+	r.logger.Warnf("config change rejected; diff vs last valid config:\n%s", diff)
+}

--- a/cmd/hyprpal/reloader_test.go
+++ b/cmd/hyprpal/reloader_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hyprpal/hyprpal/internal/config"
+	"github.com/hyprpal/hyprpal/internal/engine"
+	"github.com/hyprpal/hyprpal/internal/layout"
+	"github.com/hyprpal/hyprpal/internal/rules"
+	"github.com/hyprpal/hyprpal/internal/state"
+	"github.com/hyprpal/hyprpal/internal/util"
+)
+
+type testHyprctl struct{}
+
+func (testHyprctl) ListClients(context.Context) ([]state.Client, error)       { return nil, nil }
+func (testHyprctl) ListWorkspaces(context.Context) ([]state.Workspace, error) { return nil, nil }
+func (testHyprctl) ListMonitors(context.Context) ([]state.Monitor, error)     { return nil, nil }
+func (testHyprctl) ActiveWorkspaceID(context.Context) (int, error)            { return 0, nil }
+func (testHyprctl) ActiveClientAddress(context.Context) (string, error)       { return "", nil }
+func (testHyprctl) Dispatch(...string) error                                  { return nil }
+
+func TestReloadLogsDiffOnFailureAndKeepsPreviousConfig(t *testing.T) {
+	t.Helper()
+
+	initial := strings.TrimPrefix(`
+managedWorkspaces:
+  - 1
+modes:
+  - name: Focus
+    rules:
+      - name: Dock
+        when:
+          mode: Focus
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 1
+              side: left
+              widthPercent: 25
+              match:
+                anyClass: [Slack]
+`, "\n")
+	bad := strings.TrimPrefix(`
+managedWorkspaces:
+  - 1
+modes:
+  - name: Focus
+    rules:
+      - name: Dock
+        when:
+          mode: Focus
+        actions:
+          - type: layout.sidecarDock
+            params:
+              workspace: 1
+              side: left
+              widthPercent: 5
+              match:
+                anyClass: [Slack]
+`, "\n")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	cfg, err := config.Parse([]byte(initial))
+	if err != nil {
+		t.Fatalf("parse initial config: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate initial config: %v", err)
+	}
+	modes, err := rules.BuildModes(cfg)
+	if err != nil {
+		t.Fatalf("build modes: %v", err)
+	}
+
+	var logs bytes.Buffer
+	logger := util.NewLoggerWithWriter(util.LevelInfo, &logs)
+	eng := engine.New(testHyprctl{}, logger, modes, false, cfg.RedactTitles, layout.Gaps{
+		Inner: cfg.Gaps.Inner,
+		Outer: cfg.Gaps.Outer,
+	}, cfg.TolerancePx, cfg.ManualReserved)
+
+	reloader := newConfigReloader(path, logger, eng, cfg, []byte(initial))
+
+	if err := os.WriteFile(path, []byte(bad), 0o600); err != nil {
+		t.Fatalf("write bad config: %v", err)
+	}
+
+	err = reloader.Reload(context.Background(), "test reason")
+	if err == nil {
+		t.Fatalf("expected reload error, got nil")
+	}
+	if !strings.Contains(err.Error(), "widthPercent") {
+		t.Fatalf("expected widthPercent error, got %v", err)
+	}
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "config change rejected; diff vs last valid config") {
+		t.Fatalf("expected diff log, got %s", logOutput)
+	}
+	if strings.Contains(logOutput, "reloaded") {
+		t.Fatalf("engine should not reload modes on failure: %s", logOutput)
+	}
+
+	if err := eng.Reconcile(context.Background()); err != nil {
+		t.Fatalf("engine reconcile after failed reload: %v", err)
+	}
+	modesAfter := eng.AvailableModes()
+	if len(modesAfter) != 1 || modesAfter[0] != "Focus" {
+		t.Fatalf("unexpected modes after failed reload: %v", modesAfter)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/hyprpal/hyprpal
 go 1.22
 
 require (
-	github.com/fsnotify/fsnotify v1.9.0
-	gopkg.in/yaml.v3 v3.0.1
+        github.com/fsnotify/fsnotify v1.9.0
+        github.com/google/go-cmp v0.6.0
+        gopkg.in/yaml.v3 v3.0.1
 )
 
 require golang.org/x/sys v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -416,14 +416,23 @@ func Load(path string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read config: %w", err)
 	}
+	cfg, err := Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// Parse decodes raw configuration data and applies default values without validation.
+func Parse(data []byte) (*Config, error) {
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("decode config: %w", err)
 	}
 	cfg.applyDefaults()
-	if err := cfg.Validate(); err != nil {
-		return nil, err
-	}
 	return &cfg, nil
 }
 

--- a/internal/config/diff.go
+++ b/internal/config/diff.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// DiffSerialized returns a unified diff between two serialized configuration payloads.
+func DiffSerialized(previous, current []byte) string {
+	prevLines := splitLines(previous)
+	currLines := splitLines(current)
+	if diff := cmp.Diff(prevLines, currLines); diff != "" {
+		return diff
+	}
+	return ""
+}
+
+func splitLines(data []byte) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	text = strings.TrimSuffix(text, "\n")
+	if text == "" {
+		return []string{""}
+	}
+	return strings.Split(text, "\n")
+}

--- a/internal/config/diff_test.go
+++ b/internal/config/diff_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDiffSerialized(t *testing.T) {
+	oldData := []byte("a: 1\nb: 2\n")
+	newData := []byte("a: 1\nb: 3\n")
+
+	diff := DiffSerialized(oldData, newData)
+	if diff == "" {
+		t.Fatalf("expected diff, got empty string")
+	}
+	if !strings.Contains(diff, "b: 2") {
+		t.Fatalf("expected diff to contain original line, got %s", diff)
+	}
+	if !strings.Contains(diff, "b: 3") {
+		t.Fatalf("expected diff to contain updated line, got %s", diff)
+	}
+}


### PR DESCRIPTION
## Summary
- retain the last successful configuration and its serialized form so reloads can compare against it
- factor reloading into a helper that surfaces diffs on decode/validation/compile failures
- add unit coverage for failed reloads and diff generation

## Acceptance Criteria
- [x] Config reload failures log a diff while keeping the previous configuration active
- [x] Regression coverage prevents silent reload failures

## How to test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e1ed576a0483259c200d2d69626903