### PR TITLE
Task 6.1: Improve config reload validation and hsctl linting

### DIFF
--- a/cmd/hsctl/main.go
+++ b/cmd/hsctl/main.go
@@ -115,7 +115,11 @@ func runCheck(args []string, stdout io.Writer, stderr io.Writer) error {
 
 	fmt.Fprintf(stderr, "Configuration has %d issue(s):\n", len(lintErrs))
 	for _, lintErr := range lintErrs {
-		fmt.Fprintf(stderr, "- %s\n", lintErr.Error())
+		if lintErr.Path != "" {
+			fmt.Fprintf(stderr, "- %s: %s: %s\n", *configPath, lintErr.Path, lintErr.Message)
+			continue
+		}
+		fmt.Fprintf(stderr, "- %s: %s\n", *configPath, lintErr.Message)
 	}
 	return fmt.Errorf("configuration validation failed")
 }

--- a/cmd/hsctl/main_test.go
+++ b/cmd/hsctl/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,13 +69,13 @@ modes:
 	if !strings.Contains(output, "Configuration has") {
 		t.Fatalf("expected aggregated error output, got %q", output)
 	}
-	if !strings.Contains(output, "managedWorkspaces[0]: must be positive, got 0") {
+	if !strings.Contains(output, fmt.Sprintf("%s: managedWorkspaces[0]: must be positive, got 0", path)) {
 		t.Fatalf("missing managed workspace error: %q", output)
 	}
-	if !strings.Contains(output, "manualReserved.DP-1: cannot include negative values") {
+	if !strings.Contains(output, fmt.Sprintf("%s: manualReserved.DP-1: cannot include negative values", path)) {
 		t.Fatalf("missing manualReserved error: %q", output)
 	}
-	if !strings.Contains(output, "modes[0].rules[0].actions: must define at least one action") {
+	if !strings.Contains(output, fmt.Sprintf("%s: modes[0].rules[0].actions: must define at least one action", path)) {
 		t.Fatalf("missing rule actions error: %q", output)
 	}
 }

--- a/cmd/hyprpal/reloader_test.go
+++ b/cmd/hyprpal/reloader_test.go
@@ -120,3 +120,92 @@ modes:
 		t.Fatalf("unexpected modes after failed reload: %v", modesAfter)
 	}
 }
+
+func TestReloadLogsLintErrorsWithPaths(t *testing.T) {
+	t.Helper()
+
+	initial := strings.TrimPrefix(`
+managedWorkspaces:
+  - 1
+modes:
+  - name: Focus
+    rules:
+      - name: Dock
+        when:
+          mode: Focus
+        actions:
+          - type: layout.fullscreen
+`, "\n")
+	invalid := strings.TrimPrefix(`
+managedWorkspaces:
+  - 1
+gaps:
+  inner: -1
+modes:
+  - name: Focus
+    rules:
+      - name: Dock
+        when:
+          mode: Focus
+        actions:
+          - type: layout.fullscreen
+`, "\n")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	cfg, err := config.Parse([]byte(initial))
+	if err != nil {
+		t.Fatalf("parse initial config: %v", err)
+	}
+	if lintErrs := cfg.Lint(); len(lintErrs) > 0 {
+		t.Fatalf("initial config had lint errors: %v", lintErrs)
+	}
+	modes, err := rules.BuildModes(cfg)
+	if err != nil {
+		t.Fatalf("build modes: %v", err)
+	}
+
+	var logs bytes.Buffer
+	logger := util.NewLoggerWithWriter(util.LevelInfo, &logs)
+	eng := engine.New(testHyprctl{}, logger, modes, false, cfg.RedactTitles, layout.Gaps{
+		Inner: cfg.Gaps.Inner,
+		Outer: cfg.Gaps.Outer,
+	}, cfg.TolerancePx, cfg.ManualReserved)
+
+	reloader := newConfigReloader(path, logger, eng, cfg, []byte(initial))
+
+	if err := os.WriteFile(path, []byte(invalid), 0o600); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+
+	err = reloader.Reload(context.Background(), "lint failure")
+	if err == nil {
+		t.Fatalf("expected reload error, got nil")
+	}
+	if !strings.Contains(err.Error(), "gaps.inner") {
+		t.Fatalf("expected lint error mentioning gaps.inner, got %v", err)
+	}
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "config validation failed with 1 issue(s)") {
+		t.Fatalf("expected lint summary in logs, got %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "- gaps.inner: cannot be negative") {
+		t.Fatalf("expected lint detail in logs, got %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "config change rejected; diff vs last valid config") {
+		t.Fatalf("expected diff log, got %s", logOutput)
+	}
+
+	if err := eng.Reconcile(context.Background()); err != nil {
+		t.Fatalf("engine reconcile after failed reload: %v", err)
+	}
+	modesAfter := eng.AvailableModes()
+	if len(modesAfter) != 1 || modesAfter[0] != "Focus" {
+		t.Fatalf("unexpected modes after failed reload: %v", modesAfter)
+	}
+}


### PR DESCRIPTION
## Summary
- lint configs during reload to log detailed validation errors and keep the previous config active
- extend the reload tests to cover lint failures and ensure diffs are reported
- enhance `hsctl check` output to include file and field paths with updated unit coverage

## Acceptance Criteria
- [x] Invalid config saves are rejected without reloading the engine
- [x] Config diffs and validation issues are logged for rejected reloads
- [x] `hsctl check` prints lint errors with their source paths

## How to test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e27b126f5483258f02a7f8dd87e52f