### PR TITLE
Detect conflicting profile matcher combinations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -541,6 +542,20 @@ func (c *Config) lintMatchProfileRefs(path string, matchMap map[string]interface
 			if _, exists := c.Profiles[profileName]; !exists {
 				*errs = append(*errs, newLintError(profilePath, "references unknown profile %q", profileName))
 			}
+		}
+		conflictKeys := make([]string, 0, 2)
+		for _, key := range []string{"allOfProfiles", "anyOfProfiles"} {
+			if _, exists := matchMap[key]; exists {
+				conflictKeys = append(conflictKeys, key)
+			}
+		}
+		for _, key := range []string{"class", "anyClass", "titleRegex"} {
+			if _, exists := matchMap[key]; exists {
+				conflictKeys = append(conflictKeys, key)
+			}
+		}
+		if len(conflictKeys) > 0 {
+			*errs = append(*errs, newLintError(path, "cannot combine profile with %s", strings.Join(conflictKeys, ", ")))
 		}
 	}
 	if namesVal, ok := matchMap["allOfProfiles"]; ok {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,6 +80,47 @@ func TestValidateProfileDefinition(t *testing.T) {
 	}
 }
 
+func TestValidateProfileConflictsWithSelectors(t *testing.T) {
+	tests := map[string]map[string]interface{}{
+		"withAllOfProfiles": {
+			"profile":       "comms",
+			"allOfProfiles": []interface{}{"comms"},
+		},
+		"withAnyOfProfiles": {
+			"profile":       "comms",
+			"anyOfProfiles": []interface{}{"comms"},
+		},
+		"withClass": {
+			"profile": "comms",
+			"class":   "Slack",
+		},
+	}
+
+	for name, match := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := Config{
+				Profiles: MatcherProfiles{
+					"comms": {AnyClass: []string{"Slack", "Discord"}},
+				},
+				Modes: []ModeConfig{{
+					Name: "Test",
+					Rules: []RuleConfig{{
+						Name: "Rule",
+						When: PredicateConfig{Mode: "Test"},
+						Actions: []ActionConfig{{
+							Type:   "layout.fullscreen",
+							Params: map[string]interface{}{"match": match},
+						}},
+					}},
+				}},
+			}
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("expected validation error for conflicting selectors")
+			}
+		})
+	}
+}
+
 func TestValidateProfileAllOfCombination(t *testing.T) {
 	cfg := Config{
 		Profiles: MatcherProfiles{

--- a/internal/rules/actions.go
+++ b/internal/rules/actions.go
@@ -216,6 +216,15 @@ func parseClientMatcher(v interface{}, profiles map[string]config.MatcherConfig)
 		return nil, fmt.Errorf("match cannot combine allOfProfiles and anyOfProfiles")
 	}
 	if profileName, ok := m["profile"]; ok {
+		conflictKeys := make([]string, 0, 5)
+		for _, key := range []string{"allOfProfiles", "anyOfProfiles", "class", "anyClass", "titleRegex"} {
+			if _, exists := m[key]; exists {
+				conflictKeys = append(conflictKeys, key)
+			}
+		}
+		if len(conflictKeys) > 0 {
+			return nil, fmt.Errorf("match.profile cannot be combined with %s", strings.Join(conflictKeys, ", "))
+		}
 		name, err := assertString(profileName)
 		if err != nil {
 			return nil, err

--- a/internal/rules/actions_test.go
+++ b/internal/rules/actions_test.go
@@ -73,6 +73,39 @@ func TestParseClientMatcherProfileRegression(t *testing.T) {
 	}
 }
 
+func TestParseClientMatcherProfileConflictErrors(t *testing.T) {
+	profiles := map[string]config.MatcherConfig{
+		"comms": {AnyClass: []string{"Slack"}},
+	}
+
+	cases := map[string]map[string]interface{}{
+		"withAllOfProfiles": {
+			"profile":       "comms",
+			"allOfProfiles": []interface{}{"comms"},
+		},
+		"withAnyOfProfiles": {
+			"profile":       "comms",
+			"anyOfProfiles": []interface{}{"comms"},
+		},
+		"withClass": {
+			"profile": "comms",
+			"class":   "Slack",
+		},
+	}
+
+	for name, match := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseClientMatcher(match, profiles)
+			if err == nil {
+				t.Fatalf("expected error for conflicting selectors")
+			}
+			if !strings.Contains(err.Error(), "match.profile cannot be combined") {
+				t.Fatalf("expected descriptive profile conflict error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestParseClientMatcherAllOfProfilesErrors(t *testing.T) {
 	profiles := map[string]config.MatcherConfig{}
 


### PR DESCRIPTION
## Summary
- raise validation errors when `profile` is combined with other client matcher selectors
- ensure config linting flags conflicting profile references before runtime
- add regression tests covering invalid selector combinations in both matcher parsing and config validation

## Acceptance Criteria
- [x] Invalid matcher combinations are rejected at parse time
- [x] Configuration linting surfaces the same conflicts detected at runtime
- [x] Tests cover the newly enforced edge cases

## How to test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e2a2cdd9d88325b1d24dc2c1823f2a