### PR TITLE
Frame socket dispatch batches with begin/commit markers

### DIFF
--- a/internal/ipc/engineclient_test.go
+++ b/internal/ipc/engineclient_test.go
@@ -68,8 +68,10 @@ func TestNewEngineClientSocketStrategy(t *testing.T) {
 	}
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
 	expected := []string{
+		"begin",
 		"dispatch focuswindow address:test",
 		"dispatch movewindowpixel exact 0 0",
+		"commit",
 	}
 	if !reflect.DeepEqual(lines, expected) {
 		t.Fatalf("unexpected payload: %#v", lines)

--- a/internal/ipc/socket_test.go
+++ b/internal/ipc/socket_test.go
@@ -63,8 +63,10 @@ func TestSocketDispatcherDispatchBatch(t *testing.T) {
 	}
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
 	expected := []string{
+		"begin",
 		"dispatch focuswindow address:test",
 		"dispatch movewindowpixel exact 0 0",
+		"commit",
 	}
 	if !reflect.DeepEqual(lines, expected) {
 		t.Fatalf("unexpected payload: %#v", lines)


### PR DESCRIPTION
## Summary
- wrap multi-command socket dispatch batches with begin/commit framing while preserving single-dispatch behavior
- update socket and engine client tests to cover the new batch payload format

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e2ad630bdc8325900eedb037692f50