### PR TITLE
Handle windowtitle events incrementally

### DIFF
--- a/internal/state/world.go
+++ b/internal/state/world.go
@@ -281,6 +281,23 @@ func (w *World) MoveClient(address string, workspaceID int, monitorName string) 
 	return false, fmt.Errorf("client %s not found", address)
 }
 
+// SetClientTitle updates the cached title for a client.
+func (w *World) SetClientTitle(address, title string) (bool, error) {
+	if w == nil {
+		return false, errors.New("world is nil")
+	}
+	for i := range w.Clients {
+		if w.Clients[i].Address == address {
+			if w.Clients[i].Title == title {
+				return false, nil
+			}
+			w.Clients[i].Title = title
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("client %s not found", address)
+}
+
 // SetActiveClient updates the active client address and client focus flags.
 func (w *World) SetActiveClient(address string) bool {
 	if w == nil {


### PR DESCRIPTION
## Summary
- treat Hyprland `windowtitle` events as actionable without forcing a full reconcile
- update cached client titles through a dedicated world helper while honouring redaction mode
- extend engine tests to cover incremental `windowtitle` handling

## Acceptance Criteria
- [x] `windowtitle` events update the cached world state and trigger rule evaluation
- [x] Title redaction remains effective in traces and snapshots when enabled

## How to Test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e2da932d908325999859d3b21d9c13