### PR TITLE
Support workspace names in incremental updates

### DIFF
--- a/internal/state/world.go
+++ b/internal/state/world.go
@@ -139,6 +139,16 @@ func (w *World) WorkspaceByID(id int) *Workspace {
 	return nil
 }
 
+// WorkspaceByName finds workspace by name.
+func (w *World) WorkspaceByName(name string) *Workspace {
+	for i := range w.Workspaces {
+		if w.Workspaces[i].Name == name {
+			return &w.Workspaces[i]
+		}
+	}
+	return nil
+}
+
 // MonitorForWorkspace resolves the monitor owning the workspace ID.
 func (w *World) MonitorForWorkspace(id int) (*Monitor, error) {
 	ws := w.WorkspaceByID(id)


### PR DESCRIPTION
## Summary
- add a state.World helper to lookup workspaces by name
- resolve named workspaces in incremental engine mutations and payload parsers
- extend incremental engine tests to cover openwindow, movewindow, and workspace events with names

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2e251abb08325b40ef2ccc980e749