### PR TITLE
feat(bench): report dispatch efficiency metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Useful flags:
 - `--cpu-profile` / `--mem-profile` – emit pprof-compatible profile files for deeper analysis.
 - `--log-level` – adjust engine logging verbosity during the run (defaults to `warn`).
 
-The harness prints summary statistics after replaying the stream: total dispatches, latency percentiles (min/avg/p50/p95/max in milliseconds), and allocation counts/bytes per event. Use the Makefile target (`make bench`) for a quick replay of the synthetic fixture with the repository's example configuration.
+The harness prints summary statistics after replaying the stream: total dispatches (with per-iteration and per-event breakdowns), latency percentiles (min/avg/p50/p95/max in milliseconds), and allocation counts/bytes per event. Use the Makefile target (`make bench`) for a quick replay of the synthetic fixture with the repository's example configuration.
 
 ## Configuration
 

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -62,6 +62,7 @@ type benchAllocationStats struct {
 type benchDispatchStats struct {
 	Total        int     `json:"total"`
 	PerIteration float64 `json:"perIteration"`
+	PerEvent     float64 `json:"perEvent"`
 }
 
 type benchSummary struct {
@@ -329,6 +330,7 @@ func buildReport(fixture benchFixture, mode string, iterations int, durations []
 		Dispatches: benchDispatchStats{
 			Total:        dispatches,
 			PerIteration: safeDivide(dispatches, iterations),
+			PerEvent:     safeDivide(dispatches, totalEvents),
 		},
 		Latency: benchLatencyStats{
 			Min:    toMillis(min),

--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -118,6 +118,9 @@ func TestBuildReport(t *testing.T) {
 	if summary.Dispatches.Total != 8 {
 		t.Fatalf("Dispatches.Total = %d, want 8", summary.Dispatches.Total)
 	}
+	if math.Abs(summary.Dispatches.PerEvent-2) > 1e-9 {
+		t.Fatalf("Dispatches.PerEvent = %f, want 2", summary.Dispatches.PerEvent)
+	}
 	if math.Abs(summary.Allocations.PerEvent-125) > 1e-9 {
 		t.Fatalf("Allocations.PerEvent = %f, want 125", summary.Allocations.PerEvent)
 	}


### PR DESCRIPTION
## Summary
- add a per-event dispatch rate to the bench JSON summary so replay runs expose efficiency changes
- extend the bench unit test coverage to assert the new metric
- document the richer dispatch breakdown in the README bench section

## Testing
- go test ./cmd/...
- go test ./internal/...


------
https://chatgpt.com/codex/tasks/task_e_68e2f24a0bdc832582390598961e0029