### PR TITLE
Improve bench fixture fallbacks and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,11 @@ Pair `--log-level=trace` with `--dry-run` to audition rules without moving windo
 `make bench` wraps `go run ./cmd/bench --config configs/example.yaml --fixture fixtures/coding.json --iterations 25` to
 replay the synthetic Coding-mode fixture and capture latency/allocation stats. The command prints a JSON payload by default;
 pipe to `jq '.summary'` for the aggregated metrics that feed the table below or pass `--output bench.json` to save the full
-report for later comparison. Pass `PROFILE=1` to emit CPU/heap profiles in
-`docs/flamegraphs/` (see [docs/perf.md](docs/perf.md) for the exact workflow plus instructions for replaying your own capture).
+report for later comparison. Fixtures can be expressed as JSON snapshots (see `fixtures/coding.json`) **or** plain event logs
+containing `kind>>payload` lines; in the latter case the base world snapshot from the JSON fixture is reused. Use
+`--respect-delays` to honor any `delay` strings captured in the fixture, and `--mode` to force a particular rule mode when the
+recorded stream did not specify one. Pass `PROFILE=1` to emit CPU/heap profiles in `docs/flamegraphs/` (see
+[docs/perf.md](docs/perf.md) for the exact workflow plus instructions for replaying your own capture).
 
 **Key gains over v0.4 (synthetic Coding-mode stream, 25 iterations, Go 1.22.2 on Ryzen 7 7840U):**
 

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -486,6 +486,9 @@ func loadFixture(path string, base benchFixture) (benchFixture, error) {
 		if len(fixture.Monitors) == 0 {
 			fixture.Monitors = append([]state.Monitor(nil), base.Monitors...)
 		}
+		if fixture.Mode == "" {
+			fixture.Mode = base.Mode
+		}
 		if fixture.ActiveWorkspace == 0 {
 			fixture.ActiveWorkspace = base.ActiveWorkspace
 		}

--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -190,6 +190,36 @@ func TestLoadFixtureJSONFallbacksToBase(t *testing.T) {
 	}
 }
 
+func TestLoadFixtureJSONFallsBackToBaseMode(t *testing.T) {
+	base := defaultFixture()
+	base.Mode = "Coding"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fixture.json")
+	payload := `{
+  "name": "custom",
+  "events": [
+    {"kind": "activewindow", "payload": "0xabc"}
+  ]
+}`
+	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	fixture, err := loadFixture(path, base)
+	if err != nil {
+		t.Fatalf("loadFixture returned error: %v", err)
+	}
+	if fixture.Mode != base.Mode {
+		t.Fatalf("expected mode fallback to %q, got %q", base.Mode, fixture.Mode)
+	}
+	if fixture.Name != "custom" {
+		t.Fatalf("expected name custom, got %q", fixture.Name)
+	}
+	if len(fixture.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(fixture.Events))
+	}
+}
+
 func TestLoadFixtureJSONParsesDelay(t *testing.T) {
 	base := defaultFixture()
 	dir := t.TempDir()

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -34,8 +34,11 @@ Set `PROFILE=1` in the environment to instruct the Makefile target to add the
 `--cpu-profile`/`--mem-profile` flags. Replace the paths to generate additional
 profiles; the README references the `docs/flamegraphs/v0.5-bench-{cpu,heap}.pb.gz`
 artifacts by default. Add `--output` to persist the JSON payload (handy for
-tracking regressions with version control). Convert profiles to SVG flamegraphs
-with:
+tracking regressions with version control). Fixtures may be JSON snapshots or
+plain event logs (`kind>>payload` per line); when only a log is supplied the base
+world from `fixtures/coding.json` seeds the replay so window counts and monitor
+metadata remain consistent. Use `--respect-delays` to mirror pacing captured in
+the fixture. Convert profiles to SVG flamegraphs with:
 
 ```bash
 go tool pprof -http=:0 docs/flamegraphs/v0.5-bench-cpu.pb.gz


### PR DESCRIPTION
## Summary
- ensure cmd/bench falls back to the base mode when JSON fixtures omit it
- cover the new behaviour with a unit test and expand replay docs for log fixtures and pacing flags

## Acceptance Criteria
- [x] Bench CLI handles fixtures that rely on base metadata
- [x] Documentation calls out how to feed plain event logs and delays into the benchmark

## How to test
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2fa77d6b88325826ffd9b33fa7945