### PR TITLE
Add warm-up support to bench harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ smoke:
         go run ./cmd/smoke --config configs/example.yaml
 
 bench:
-        if [ "$(PROFILE)" = "1" ]; then \
-                mkdir -p docs/flamegraphs; \
-                go run ./cmd/bench --config configs/example.yaml --fixture fixtures/coding.json --iterations 25 --cpu-profile docs/flamegraphs/v0.5-bench-cpu.pb.gz --mem-profile docs/flamegraphs/v0.5-bench-heap.pb.gz; \
-        else \
-                go run ./cmd/bench --config configs/example.yaml --fixture fixtures/coding.json --iterations 25; \
-        fi
+	if [ "$(PROFILE)" = "1" ]; then \
+		mkdir -p docs/flamegraphs; \
+		go run ./cmd/bench --config configs/example.yaml --fixture fixtures/coding.json --iterations 25 --warmup 3 --cpu-profile docs/flamegraphs/v0.5-bench-cpu.pb.gz --mem-profile docs/flamegraphs/v0.5-bench-heap.pb.gz; \
+	else \
+		go run ./cmd/bench --config configs/example.yaml --fixture fixtures/coding.json --iterations 25 --warmup 3; \
+	fi
 
 install:
         mkdir -p $(INSTALL_DIR)

--- a/README.md
+++ b/README.md
@@ -92,16 +92,17 @@ The `--explain` flag (enabled by default) annotates each dispatch with its `mode
 Run the harness against the default synthetic fixture (a Coding workspace with dockable comms windows) or point it at your own capture:
 
 ```bash
-# Replay the default synthetic stream 25 times
-go run ./cmd/bench --iterations 25 --config configs/example.yaml
+# Replay the default synthetic stream 25 times with three warm-up passes
+go run ./cmd/bench --iterations 25 --warmup 3 --config configs/example.yaml
 
 # Replay a custom JSON fixture with CPU/heap profiles
 go run ./cmd/bench --config ~/.config/hyprpal/config.yaml \
-  --fixture fixtures/coding.json --cpu-profile bench.cpu --mem-profile bench.mem
+  --fixture fixtures/coding.json --iterations 25 --warmup 3 \
+  --cpu-profile bench.cpu --mem-profile bench.mem
 ```
 
-Prefer a canned workflow? `make bench` replays the default fixture 25 times and
-honors `PROFILE=1 make bench` to emit CPU/heap profiles under
+Prefer a canned workflow? `make bench` replays the default fixture 25 times (with
+three warm-up passes) and honors `PROFILE=1 make bench` to emit CPU/heap profiles under
 `docs/flamegraphs/`. The [performance note](./docs/perf.md) shows the resulting
 benchmarks versus v0.4 and explains how to turn those profiles into flamegraphs.
 
@@ -113,6 +114,7 @@ The fixture supports two formats:
 Useful flags:
 
 - `--iterations` – number of times to replay the stream (default `10`).
+- `--warmup` – warm-up iterations to discard before timing begins (default `0`).
 - `--mode` – override the mode selected before the first reconcile.
 - `--respect-delays` – sleep for any `delay` values encoded in the fixture events.
 - `--cpu-profile` / `--mem-profile` – emit pprof-compatible profile files for deeper analysis.

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -41,6 +41,7 @@ PROFILE=1 go run ./cmd/bench \
   --config configs/example.yaml \
   --fixture fixtures/coding.json \
   --iterations 25 \
+  --warmup 3 \
   --output docs/flamegraphs/v0.5-bench.json \
   --event-trace docs/flamegraphs/v0.5-events.json \
   --cpu-profile docs/flamegraphs/v0.5-bench-cpu.pb.gz \
@@ -48,9 +49,11 @@ PROFILE=1 go run ./cmd/bench \
 ```
 
 Set `PROFILE=1` in the environment to instruct the Makefile target to add the
-`--cpu-profile`/`--mem-profile` flags. Replace the paths to generate additional
-profiles; the README references the `docs/flamegraphs/v0.5-bench-{cpu,heap}.pb.gz`
-artifacts by default. Add `--output` to persist the JSON payload (handy for
+`--cpu-profile`/`--mem-profile` flags. Both workflows run three warm-up
+iterations before measurement so cold-start allocations don't skew results.
+Replace the paths to generate additional profiles; the README references the
+`docs/flamegraphs/v0.5-bench-{cpu,heap}.pb.gz` artifacts by default. Add
+`--output` to persist the JSON payload (handy for
 tracking regressions with version control) and `--event-trace` to mirror the raw
 per-event timings that help pinpoint spikes. Fixtures may be JSON snapshots or
 plain event logs (`kind>>payload` per line); when only a log is supplied the base


### PR DESCRIPTION
## Summary
- add a --warmup flag and warm-up replay loop to cmd/bench, sharing iteration logic and reporting the warm-up count in JSON and human summaries
- cover the new reporting fields with unit tests and keep existing buildReport expectations in sync
- document the recommended warm-up usage in README/docs and default `make bench` to execute three warm-up passes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e42dadabc883258c1d9f5fc4d373d6