### PR TITLE
docs: document reproducing v0.4 benchmark baseline

### DIFF
--- a/docs/perf.md
+++ b/docs/perf.md
@@ -66,6 +66,36 @@ go tool pprof -http=:0 docs/flamegraphs/v0.5-bench-cpu.pb.gz
 Repeat for the heap profile. Keep both the `.pb.gz` (raw profile) and `.svg`
 (rendered flamegraph) if you plan to check them into documentation.
 
+## Reproducing the v0.4 baseline
+
+Use the same harness to re-run the fixture against the v0.4 branch when you
+need to regenerate the comparison numbers. The commands below assume you have
+the repository cloned twice side-by-side; swap the paths if you prefer a single
+checkout and `git worktree`:
+
+```bash
+# Old tree: run the v0.4 engine with the synthetic fixture
+cd ~/code/hyprpal-v0.4
+PROFILE=1 go run ./cmd/bench \
+  --config configs/example.yaml \
+  --fixture fixtures/coding.json \
+  --iterations 25 \
+  --output ~/bench/v0.4.json \
+  --cpu-profile ~/bench/v0.4-cpu.pb.gz \
+  --mem-profile ~/bench/v0.4-heap.pb.gz
+
+# New tree: repeat with the current branch
+cd ~/code/hyprpal
+PROFILE=1 make bench
+
+# Collate the summary rows for a quick diff
+jq '.summary' ~/bench/v0.4.json docs/flamegraphs/v0.5-bench.json
+```
+
+The saved JSON lets you keep historical runs in source control. Commit the
+profiles alongside the summaries when you want a permanent record of the
+flamegraphs referenced by release notes.
+
 ## Raw benchmark output
 
 The numbers below are averaged over 25 iterations of the synthetic Coding-mode


### PR DESCRIPTION
## Summary
- add documentation describing how to regenerate the v0.4 benchmark baseline using cmd/bench
- note how to store JSON summaries and profiles for future release references

## Acceptance Criteria
- [x] Updated performance guide includes commands for replaying the v0.4 engine
- [x] Guidance provided for capturing benchmark artefacts for release notes

## How to test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e430bd4ad88325a55b6bbbf4ca8795