### PR TITLE
Improve bench report output handling

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -510,6 +510,12 @@ func writeReport(report benchReport, outputPath string) error {
 	case "", "-":
 		w = os.Stdout
 	default:
+		dir := filepath.Dir(outputPath)
+		if dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("create report dir: %w", err)
+			}
+		}
 		out, err = os.Create(outputPath)
 		if err != nil {
 			return err
@@ -519,6 +525,7 @@ func writeReport(report benchReport, outputPath string) error {
 	}
 
 	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 	return enc.Encode(report)
 }

--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -220,6 +220,27 @@ func TestWriteEventTrace(t *testing.T) {
 	}
 }
 
+func TestWriteReportCreatesDirAndSkipsHTMLEscape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "report.json")
+	report := benchReport{
+		Summary: benchSummary{Fixture: "<fixture>", Mode: "Coding"},
+	}
+
+	if err := writeReport(report, path); err != nil {
+		t.Fatalf("writeReport returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	contents := string(raw)
+	if !strings.Contains(contents, "\"fixture\": \"<fixture>\"") {
+		t.Fatalf("expected raw angle brackets in output, got:\n%s", contents)
+	}
+}
+
 func TestLoadFixtureJSONMergesBase(t *testing.T) {
 	base := defaultFixture()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- ensure `cmd/bench` creates parent directories before writing JSON summaries and keeps HTML untouched in the payload
- add a regression test covering nested output paths and verifying the summary fixture name is not escaped

## Acceptance Criteria
- [x] `cmd/bench` can emit a report into a nested directory without failing
- [x] JSON summaries preserve literal `<fixture>` strings instead of HTML-escaped sequences

## How to Test
1. `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e43889971083259f52457082c7bafb