### PR TITLE
Add configurable rule throttles and engine rule status APIs

### DIFF
--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1,0 +1,39 @@
+package rules
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyprpal/hyprpal/internal/config"
+)
+
+func TestBuildModesPropagatesThrottle(t *testing.T) {
+	cfg := &config.Config{
+		Modes: []config.ModeConfig{{
+			Name: "Test",
+			Rules: []config.RuleConfig{{
+				Name:     "Limited",
+				Actions:  []config.ActionConfig{{Type: "layout.fullscreen"}},
+				Throttle: &config.RuleThrottle{FiringLimit: 5, WindowMs: 2000},
+			}},
+		}},
+	}
+
+	modes, err := BuildModes(cfg)
+	if err != nil {
+		t.Fatalf("BuildModes returned error: %v", err)
+	}
+	if len(modes) != 1 || len(modes[0].Rules) != 1 {
+		t.Fatalf("unexpected modes length: %+v", modes)
+	}
+	throttle := modes[0].Rules[0].Throttle
+	if throttle == nil {
+		t.Fatalf("expected throttle to be set")
+	}
+	if throttle.FiringLimit != 5 {
+		t.Fatalf("unexpected firing limit: %d", throttle.FiringLimit)
+	}
+	if throttle.Window != 2*time.Second {
+		t.Fatalf("unexpected throttle window: %v", throttle.Window)
+	}
+}


### PR DESCRIPTION
## Summary
- allow rules to declare throttle limits and validate them during linting
- propagate throttle data into compiled rules and add coverage for BuildModes
- refactor the engine to enforce per-rule throttles, expose status/enable APIs, and extend tests for throttling behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e43ed3c3748325a042158286f333ee