### PR TITLE
feat: surface rule status controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ hsctl plan --explain
 
 When no actions are queued, `hsctl` prints `No pending actions`.
 
+### Inspect rule counters and re-enable throttled rules
+
+Audit how often each rule has executed and which ones are currently disabled (for example due to throttle guardrails):
+
+```bash
+hsctl rules status
+# Rule counters:
+#   [Coding] Dock comms: total=42
+#   [Coding] Fullscreen active: total=17
+#
+# Disabled rules:
+#   [Gaming] Pause layout adjustments - disabled (since 2024-05-01T18:30:00Z)
+```
+
+Bring a rule back online once you've investigated the root cause. Pass the mode name followed by the rule name:
+
+```bash
+hsctl rules enable Gaming "Pause layout adjustments"
+# Rule Pause layout adjustments re-enabled in mode Gaming
+```
+
 ## `smoke` world snapshot CLI
 
 `cmd/smoke` is a standalone helper that bootstraps the rule engine with a no-op dispatcher. It loads your configuration, captures a one-off world snapshot with the regular Hyprland queries, prints both structures, and evaluates the active mode to show the pending dispatches alongside the rule that generated them. Use it when iterating on YAML changes outside of Hyprland or when you want to verify predicate logic without letting the daemon mutate windows.

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -155,6 +155,17 @@ While the daemon is running:
 
   Empty output indicates no pending actions for the current world state.
 
+- **Inspect and recover rule counters**
+  ```bash
+  hsctl rules status
+  ```
+
+  Disabled rules are grouped separately along with their throttle reason and timestamp. To re-enable one:
+
+  ```bash
+  hsctl rules enable Gaming "Pause layout adjustments"
+  ```
+
 ---
 
 ## 7. Enable the Systemd User Service

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -20,6 +20,8 @@ const (
 	ActionPlan         = "plan"
 	ActionInspect      = "inspect" // legacy alias for inspector.get
 	ActionInspectorGet = "inspector.get"
+	ActionRulesStatus  = "rules.status"
+	ActionRuleEnable   = "rules.enable"
 
 	// Response statuses.
 	StatusOK    = "ok"
@@ -71,6 +73,23 @@ type InspectorSnapshot struct {
 	Mode    ModeStatus       `json:"mode"`
 	World   *state.World     `json:"world"`
 	History []RuleEvaluation `json:"history,omitempty"`
+}
+
+// RuleStatus describes a rule's execution counters and disablement state as exposed over the
+// control API.
+type RuleStatus struct {
+	Mode             string      `json:"mode"`
+	Rule             string      `json:"rule"`
+	TotalExecutions  int         `json:"totalExecutions"`
+	RecentExecutions []time.Time `json:"recentExecutions,omitempty"`
+	Disabled         bool        `json:"disabled"`
+	DisabledReason   string      `json:"disabledReason,omitempty"`
+	DisabledSince    time.Time   `json:"disabledSince,omitempty"`
+}
+
+// RulesStatus aggregates the execution state for all loaded rules.
+type RulesStatus struct {
+	Rules []RuleStatus `json:"rules"`
 }
 
 // DefaultSocketPath returns the expected location of the hyprpal control socket.


### PR DESCRIPTION
## Summary
- expose `rules.status` and `rules.enable` actions through the control server and client
- add CLI support for `hsctl rules status|enable` plus docs covering the new flow
- extend unit coverage around the new API surface and CLI formatting

## Acceptance Criteria
- [x] Control server forwards rule status and enable requests to the engine with structured payloads
- [x] hsctl can inspect counters/disabled rules and re-enable rules through the client
- [x] Documentation highlights the new CLI capabilities

## How to Test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e460cd64d88325b92c2cb6cc730328