### PR TITLE
feat: add multi-window rule throttles and hsctl surfacing

### DIFF
--- a/cmd/hsctl/main_test.go
+++ b/cmd/hsctl/main_test.go
@@ -108,7 +108,10 @@ func (f *fakeRulesClient) EnableRule(_ context.Context, mode, rule string) error
 func TestRunRulesStatus(t *testing.T) {
 	now := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
 	client := &fakeRulesClient{status: controlclient.RulesStatus{Rules: []controlclient.RuleStatus{
-		{Mode: "Coding", Rule: "Dock", TotalExecutions: 3},
+		{Mode: "Coding", Rule: "Dock", TotalExecutions: 3, Throttle: &controlclient.RuleThrottle{Windows: []controlclient.RuleThrottleWindow{{
+			FiringLimit: 3,
+			WindowMs:    2000,
+		}}}},
 		{Mode: "Coding", Rule: "Throttle", TotalExecutions: 5, Disabled: true, DisabledReason: "throttle", DisabledSince: now},
 	}}}
 	var buf bytes.Buffer
@@ -119,7 +122,7 @@ func TestRunRulesStatus(t *testing.T) {
 	if !strings.Contains(output, "Rule counters:") {
 		t.Fatalf("expected counters header in output: %q", output)
 	}
-	if !strings.Contains(output, "[Coding] Dock: total=3") {
+	if !strings.Contains(output, "[Coding] Dock: total=3 (throttle: 3 in 2s)") {
 		t.Fatalf("missing dock counter: %q", output)
 	}
 	if !strings.Contains(output, "Disabled rules:") {

--- a/internal/control/client/client.go
+++ b/internal/control/client/client.go
@@ -34,6 +34,10 @@ type (
 	InspectorState = control.InspectorSnapshot
 	// RuleStatus mirrors the rule counter payload returned by the daemon.
 	RuleStatus = control.RuleStatus
+	// RuleThrottle mirrors the throttle window payload returned by the daemon.
+	RuleThrottle = control.RuleThrottle
+	// RuleThrottleWindow mirrors a single throttle window configuration.
+	RuleThrottleWindow = control.RuleThrottleWindow
 	// RulesStatus aggregates rule execution state for all modes.
 	RulesStatus = control.RulesStatus
 )

--- a/internal/control/client/client_test.go
+++ b/internal/control/client/client_test.go
@@ -52,6 +52,10 @@ func TestRulesStatusSuccess(t *testing.T) {
 			Disabled:         true,
 			DisabledReason:   "throttle",
 			DisabledSince:    now,
+			Throttle: &control.RuleThrottle{Windows: []control.RuleThrottleWindow{{
+				FiringLimit: 5,
+				WindowMs:    2000,
+			}}},
 		}}}}
 		if err := json.NewEncoder(conn).Encode(resp); err != nil {
 			t.Errorf("encode response: %v", err)
@@ -74,6 +78,9 @@ func TestRulesStatusSuccess(t *testing.T) {
 	}
 	if !got.Disabled || got.DisabledReason != "throttle" {
 		t.Fatalf("expected disabled rule with reason, got %#v", got)
+	}
+	if got.Throttle == nil || len(got.Throttle.Windows) != 1 {
+		t.Fatalf("expected throttle windows in status: %#v", got.Throttle)
 	}
 }
 

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -78,18 +78,30 @@ type InspectorSnapshot struct {
 // RuleStatus describes a rule's execution counters and disablement state as exposed over the
 // control API.
 type RuleStatus struct {
-	Mode             string      `json:"mode"`
-	Rule             string      `json:"rule"`
-	TotalExecutions  int         `json:"totalExecutions"`
-	RecentExecutions []time.Time `json:"recentExecutions,omitempty"`
-	Disabled         bool        `json:"disabled"`
-	DisabledReason   string      `json:"disabledReason,omitempty"`
-	DisabledSince    time.Time   `json:"disabledSince,omitempty"`
+	Mode             string        `json:"mode"`
+	Rule             string        `json:"rule"`
+	TotalExecutions  int           `json:"totalExecutions"`
+	RecentExecutions []time.Time   `json:"recentExecutions,omitempty"`
+	Disabled         bool          `json:"disabled"`
+	DisabledReason   string        `json:"disabledReason,omitempty"`
+	DisabledSince    time.Time     `json:"disabledSince,omitempty"`
+	Throttle         *RuleThrottle `json:"throttle,omitempty"`
 }
 
 // RulesStatus aggregates the execution state for all loaded rules.
 type RulesStatus struct {
 	Rules []RuleStatus `json:"rules"`
+}
+
+// RuleThrottle mirrors the engine throttle configuration for control clients.
+type RuleThrottle struct {
+	Windows []RuleThrottleWindow `json:"windows"`
+}
+
+// RuleThrottleWindow describes a single sliding window threshold.
+type RuleThrottleWindow struct {
+	FiringLimit int `json:"firingLimit"`
+	WindowMs    int `json:"windowMs"`
 }
 
 // DefaultSocketPath returns the expected location of the hyprpal control socket.

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -30,10 +30,13 @@ func TestBuildModesPropagatesThrottle(t *testing.T) {
 	if throttle == nil {
 		t.Fatalf("expected throttle to be set")
 	}
-	if throttle.FiringLimit != 5 {
-		t.Fatalf("unexpected firing limit: %d", throttle.FiringLimit)
+	if len(throttle.Windows) != 1 {
+		t.Fatalf("expected one throttle window, got %d", len(throttle.Windows))
 	}
-	if throttle.Window != 2*time.Second {
-		t.Fatalf("unexpected throttle window: %v", throttle.Window)
+	if throttle.Windows[0].FiringLimit != 5 {
+		t.Fatalf("unexpected firing limit: %d", throttle.Windows[0].FiringLimit)
+	}
+	if throttle.Windows[0].Window != 2*time.Second {
+		t.Fatalf("unexpected throttle window: %v", throttle.Windows[0].Window)
 	}
 }


### PR DESCRIPTION
## Summary
- support multiple sliding-window thresholds per rule and tighten configuration linting
- update engine bookkeeping to track per-window counts, auto-disable on breaches, and expose throttle metadata
- expose throttle details in the control API and hsctl output with CLI affordances and tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e583110cf08325a877e32ed0b148c5