### PR TITLE
Enhance throttle disable messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ hsctl rules status
 #   [Coding] Fullscreen active: total=17
 #
 # Disabled rules:
-#   [Gaming] Pause layout adjustments - disabled (since 2024-05-01T18:30:00Z)
+#   [Gaming] Pause layout adjustments - disabled (throttle: 3 in 2s since 2024-05-01T18:30:00Z)
 ```
 
 Bring a rule back online once you've investigated the root cause. Pass the mode name followed by the rule name:

--- a/cmd/hsctl/main_test.go
+++ b/cmd/hsctl/main_test.go
@@ -112,7 +112,7 @@ func TestRunRulesStatus(t *testing.T) {
 			FiringLimit: 3,
 			WindowMs:    2000,
 		}}}},
-		{Mode: "Coding", Rule: "Throttle", TotalExecutions: 5, Disabled: true, DisabledReason: "throttle", DisabledSince: now},
+		{Mode: "Coding", Rule: "Throttle", TotalExecutions: 5, Disabled: true, DisabledReason: "disabled (throttle: 5 in 2s)", DisabledSince: now},
 	}}}
 	var buf bytes.Buffer
 	if err := runRules(context.Background(), client, []string{"status"}, &buf); err != nil {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -534,7 +534,7 @@ func TestRuleThrottleDisablesAfterLimit(t *testing.T) {
 	records := eng.RuleCheckHistory()
 	seenDisabled := false
 	for _, rec := range records {
-		if rec.Rule == rule.Name && rec.Reason == "disabled (throttle)" {
+		if rec.Rule == rule.Name && rec.Reason == "disabled (throttle: 2 in 10s)" {
 			seenDisabled = true
 			break
 		}
@@ -552,7 +552,7 @@ func TestRuleThrottleDisablesAfterLimit(t *testing.T) {
 			if st.TotalExecutions != 2 {
 				t.Fatalf("expected total executions 2, got %d", st.TotalExecutions)
 			}
-			if st.DisabledReason != "disabled (throttle)" {
+			if st.DisabledReason != "disabled (throttle: 2 in 10s)" {
 				t.Fatalf("unexpected disabled reason: %#v", st)
 			}
 			return
@@ -601,7 +601,7 @@ func TestRuleThrottleDisablesOnSecondaryWindow(t *testing.T) {
 			if !st.Disabled {
 				t.Fatalf("expected rule to be disabled after hitting secondary window, got %#v", st)
 			}
-			if st.DisabledReason != "disabled (throttle)" {
+			if st.DisabledReason != "disabled (throttle: 3 in 2s)" {
 				t.Fatalf("unexpected disabled reason: %#v", st)
 			}
 			if st.TotalExecutions != 3 {


### PR DESCRIPTION
## Summary
- add structured throttle window helpers so rule disable reasons include the limit that fired
- surface the formatted throttle reason in engine logs, rule status responses, and CLI output
- refresh docs and CLI tests to demonstrate the richer disable messaging

## Acceptance Criteria
- [x] Per-rule throttle disable reasons explain which window triggered the guardrail
- [x] `hsctl rules status` surfaces throttle information for disabled rules

## How to test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e58b2d027483258ef30b657d26c34e