### PR TITLE
Expose predicate traces in plan responses

### DIFF
--- a/cmd/hsctl/main.go
+++ b/cmd/hsctl/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -188,6 +189,12 @@ func runPlan(ctx context.Context, cli *client.Client, args []string) error {
 		if cmd.Reason != "" {
 			fmt.Printf("  reason: %s\n", cmd.Reason)
 		}
+		if *explain && cmd.Predicate != nil {
+			fmt.Println("  predicate:")
+			if err := printIndentedJSON(cmd.Predicate, "    "); err != nil {
+				return fmt.Errorf("format predicate: %w", err)
+			}
+		}
 	}
 	return nil
 }
@@ -198,6 +205,18 @@ func runTUI(cli *client.Client) error {
 	renderer := tui.New(cli, os.Stdout)
 	if err := renderer.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return err
+	}
+	return nil
+}
+
+func printIndentedJSON(v any, indent string) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		fmt.Printf("%s%s\n", indent, line)
 	}
 	return nil
 }

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -206,8 +206,9 @@ func (s *Server) handlePlan(ctx context.Context, conn net.Conn, params map[strin
 	result := PlanResult{Commands: make([]PlanCommand, 0, len(commands))}
 	for _, cmd := range commands {
 		result.Commands = append(result.Commands, PlanCommand{
-			Dispatch: cmd.Dispatch,
-			Reason:   cmd.Reason,
+			Dispatch:  cmd.Dispatch,
+			Reason:    cmd.Reason,
+			Predicate: rules.ClonePredicateTrace(cmd.Predicate),
 		})
 	}
 	s.writeOK(conn, result)

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/hyprpal/hyprpal/internal/rules"
 	"github.com/hyprpal/hyprpal/internal/state"
 )
 
@@ -49,8 +50,9 @@ type ModeStatus struct {
 
 // PlanCommand represents a single hyprctl dispatch planned by the daemon.
 type PlanCommand struct {
-	Dispatch []string `json:"dispatch"`
-	Reason   string   `json:"reason,omitempty"`
+	Dispatch  []string              `json:"dispatch"`
+	Reason    string                `json:"reason,omitempty"`
+	Predicate *rules.PredicateTrace `json:"predicate,omitempty"`
 }
 
 // PlanResult captures the commands returned by the daemon when planning.


### PR DESCRIPTION
## Summary
- attach predicate traces to planned commands in the engine and surface them via the control API
- teach hsctl plan --explain to pretty-print predicate traces
- cover predicate propagation with control server/client tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e5b84d6a488325a92574097dcfade6