### PR TITLE
Add bench explain logging with predicate traces

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -756,6 +756,16 @@ func (e *Engine) RuleCheckHistory() []RuleCheckRecord {
 	return e.ruleChecks.snapshot()
 }
 
+// ClearRuleCheckHistory removes any buffered rule evaluation records.
+func (e *Engine) ClearRuleCheckHistory() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.ruleChecks == nil {
+		return
+	}
+	e.ruleChecks.clear()
+}
+
 func (e *Engine) evaluate(world *state.World, now time.Time, log bool) (layout.Plan, []plannedRule) {
 	e.mu.Lock()
 	activeMode := e.activeMode
@@ -982,6 +992,14 @@ func (h *ruleCheckHistory) snapshot() []RuleCheckRecord {
 		out[i] = cloneRuleCheckRecord(h.buf[idx])
 	}
 	return out
+}
+
+func (h *ruleCheckHistory) clear() {
+	if h == nil {
+		return
+	}
+	h.start = 0
+	h.count = 0
 }
 
 func cloneRuleCheckRecord(record RuleCheckRecord) RuleCheckRecord {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -337,6 +337,23 @@ func TestEvaluateStopsAfterHigherPriorityMutations(t *testing.T) {
 	}
 }
 
+func TestClearRuleCheckHistory(t *testing.T) {
+	hypr := &fakeHyprctl{}
+	var logs bytes.Buffer
+	logger := util.NewLoggerWithWriter(util.LevelInfo, &logs)
+	eng := New(hypr, logger, nil, false, false, layout.Gaps{}, 0, nil)
+
+	eng.recordRuleCheck(RuleCheckRecord{Rule: "demo", Matched: true})
+	if got := len(eng.RuleCheckHistory()); got != 1 {
+		t.Fatalf("expected 1 record before clear, got %d", got)
+	}
+
+	eng.ClearRuleCheckHistory()
+	if got := len(eng.RuleCheckHistory()); got != 0 {
+		t.Fatalf("expected no records after clear, got %d", got)
+	}
+}
+
 func TestEvaluateContinuesWhenHigherPriorityNoOp(t *testing.T) {
 	hypr := &fakeHyprctl{
 		workspaces:      []state.Workspace{{ID: 1, Name: "dev", MonitorName: "HDMI-A-1"}},


### PR DESCRIPTION
## Summary
- add an `--explain` flag to the bench command and thread it through the replay loop
- log matched rule predicate traces per event when explanations are enabled
- add engine utilities and tests to clear rule history and cover the new explain output

## Checklist
- [x] `cmd/bench` supports per-event predicate explanations via `--explain`
- [x] Rule-check history is isolated per event to avoid cross-talk between logs
- [x] Added automated tests covering explanation logging and history clearing

## How to Test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e5ba34d4888325870723aec017ba47