### PR TITLE
feat: surface action metadata in plan explain output

### DIFF
--- a/cmd/hsctl/main.go
+++ b/cmd/hsctl/main.go
@@ -185,6 +185,13 @@ func runPlan(ctx context.Context, cli *client.Client, args []string) error {
 		return nil
 	}
 	for _, cmd := range result.Commands {
+		if *explain {
+			action := cmd.Action
+			if action == "" {
+				action = "(unknown action)"
+			}
+			fmt.Printf("action: %s\n", action)
+		}
 		fmt.Printf("dispatch: %s\n", strings.Join(cmd.Dispatch, " "))
 		if cmd.Reason != "" {
 			fmt.Printf("  reason: %s\n", cmd.Reason)

--- a/cmd/smoke/main.go
+++ b/cmd/smoke/main.go
@@ -98,6 +98,13 @@ func main() {
 	} else {
 		fmt.Println("\n=== Planned Commands ===")
 		for _, cmd := range commands {
+			if *explain {
+				action := cmd.Action
+				if action == "" {
+					action = "(unknown action)"
+				}
+				fmt.Printf("action: %s\n", action)
+			}
 			fmt.Printf("dispatch: %s\n", formatCommand(cmd.Dispatch))
 			if cmd.Reason != "" {
 				fmt.Printf("  reason: %s\n", cmd.Reason)

--- a/internal/control/client/client_test.go
+++ b/internal/control/client/client_test.go
@@ -182,6 +182,7 @@ func TestPlanIncludesPredicateTrace(t *testing.T) {
 		resp := control.Response{Status: control.StatusOK, Data: control.PlanResult{Commands: []control.PlanCommand{{
 			Dispatch:  []string{"dispatch"},
 			Reason:    "Mode:Rule",
+			Action:    "layout.test",
 			Predicate: &rules.PredicateTrace{Kind: "predicate", Result: true},
 		}}}}
 		if err := json.NewEncoder(conn).Encode(resp); err != nil {
@@ -198,6 +199,9 @@ func TestPlanIncludesPredicateTrace(t *testing.T) {
 	}
 	if len(result.Commands) != 1 {
 		t.Fatalf("expected one command, got %d", len(result.Commands))
+	}
+	if result.Commands[0].Action != "layout.test" {
+		t.Fatalf("expected action in plan result, got %q", result.Commands[0].Action)
 	}
 	if result.Commands[0].Predicate == nil {
 		t.Fatalf("expected predicate trace in plan result")

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -208,6 +208,7 @@ func (s *Server) handlePlan(ctx context.Context, conn net.Conn, params map[strin
 		result.Commands = append(result.Commands, PlanCommand{
 			Dispatch:  cmd.Dispatch,
 			Reason:    cmd.Reason,
+			Action:    cmd.Action,
 			Predicate: rules.ClonePredicateTrace(cmd.Predicate),
 		})
 	}

--- a/internal/control/server_test.go
+++ b/internal/control/server_test.go
@@ -60,6 +60,14 @@ func (a stubAction) Plan(rules.ActionContext) (layout.Plan, error) {
 	return a.plan, nil
 }
 
+func wrapRuleAction(actionType string, impl rules.Action) rules.RuleAction {
+	return rules.RuleAction{Type: actionType, Impl: impl}
+}
+
+func stubRuleAction(plan layout.Plan) rules.RuleAction {
+	return wrapRuleAction("test.stub", stubAction{plan: plan})
+}
+
 func TestHandleModeSetTriggersReconcile(t *testing.T) {
 	hyprctl := &fakeHyprctl{}
 	logger := util.NewLoggerWithWriter(util.LevelError, io.Discard)
@@ -217,8 +225,8 @@ func TestHandlePlanIncludesPredicate(t *testing.T) {
 			Name:   "Rule",
 			When:   func(rules.EvalContext) bool { return true },
 			Tracer: &rules.PredicateTracer{},
-			Actions: []rules.Action{
-				stubAction{plan: plan},
+			Actions: []rules.RuleAction{
+				stubRuleAction(plan),
 			},
 		}},
 	}}

--- a/internal/control/types.go
+++ b/internal/control/types.go
@@ -52,6 +52,7 @@ type ModeStatus struct {
 type PlanCommand struct {
 	Dispatch  []string              `json:"dispatch"`
 	Reason    string                `json:"reason,omitempty"`
+	Action    string                `json:"action,omitempty"`
 	Predicate *rules.PredicateTrace `json:"predicate,omitempty"`
 }
 

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -13,7 +13,7 @@ type Rule struct {
 	Name              string
 	When              Predicate
 	Tracer            *PredicateTracer
-	Actions           []Action
+	Actions           []RuleAction
 	Debounce          time.Duration
 	MutateUnmanaged   bool
 	ManagedWorkspaces map[int]struct{}


### PR DESCRIPTION
## Summary
- capture action identifiers while building engine plans so explain responses can attribute each dispatch
- mirror the new action metadata through the control API and CLI explain output
- update smoke tooling and tests to account for the additional action context

## Acceptance Criteria
- [x] `hsctl plan --explain` shows the originating action for each dispatch
- [x] Control plan responses include action metadata when explain is requested

## How to test
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e5bf9c199483258838437c48912eed